### PR TITLE
Remove need to workaround in corefx.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+; EditorConfig helps developers define and maintain consistent
+; coding styles between different editors and IDEs.
+
+; For more visit http://editorconfig.org.
+root = true
+
+; Choose between lf or rf on "end_of_line" property
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{*proj,targets,props}]
+indent_size = 2
+
+[*.{cs,md}]
+indent_size = 4

--- a/build.proj
+++ b/build.proj
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="src/index/index.proj"/>
+
+  <Target Name="BuildTasks">
+    <MSBuild Projects="src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj" Targets="Build">
+      <Output TaskParameter="TargetOutputs" PropertyName="SourceIndexerTasksAssembly"/>
+    </MSBuild>
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="BuildTasks">
+    <MSBuild Projects="src/index/index.proj" Targets="Rebuild" Properties="SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)"/>
+  </Target>
+  <Target Name="Clean" DependsOnTargets="BuildTasks">
+    <MSBuild Projects="src/index/index.proj" Targets="Clean" Properties="SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)"/>
+  </Target>
+  <Target Name="Build" DependsOnTargets="BuildTasks">
+    <MSBuild Projects="src/index/index.proj" Targets="Build" Properties="SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)"/>
+  </Target>
+  <Target Name="Clone" DependsOnTargets="BuildTasks">
+    <MSBuild Projects="src/index/index.proj" Targets="Clone" Properties="SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)"/>
+  </Target>
+  <Target Name="SelectProjects" DependsOnTargets="BuildTasks">
+    <MSBuild Projects="src/index/index.proj" Targets="SelectProjects" Properties="SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)"/>
+  </Target>
 </Project>

--- a/src/Microsoft.SourceIndexer.Tasks/Extensions.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/Extensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.SourceIndexer.Tasks
+{
+    public static class Extensions
+    {
+        public static BuildEngineResult BuildProjectFilesInParallel(this IBuildEngine3 engine, string[] projectFileNames, string targetNames, IDictionary globalProperties, IList<string> removeGlobalProperties, string toolsVersion, bool returnTargetOutputs)
+        {
+            return engine.BuildProjectFilesInParallel(
+                projectFileNames,
+                CreateArray(targetNames, 1),
+                CreateArray(globalProperties, projectFileNames.Length),
+                CreateArray(removeGlobalProperties, projectFileNames.Length),
+                CreateArray(toolsVersion, projectFileNames.Length),
+                returnTargetOutputs
+            );
+        }
+
+        private static T[] CreateArray<T>(T value, int count)
+        {
+            return Enumerable.Repeat(value, count).ToArray();
+        }
+    }
+}

--- a/src/Microsoft.SourceIndexer.Tasks/GenerateLiveReferenceCache.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/GenerateLiveReferenceCache.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.SourceIndexer.Tasks
+{
+    public class LiveReferenceData
+    {
+        public string Project { get; set; }
+        public string TargetPath { get; set; }
+    }
+
+    public class GenerateLiveReferenceCache : Task
+    {
+        [Required]
+        public ITaskItem[] CandidateReferenceProjects { get; set; }
+
+        public string SetProperties { get; set; } = string.Empty;
+
+        public string UndefineProperties { get; set; } = string.Empty;
+
+        [Required]
+        public string LiveReferenceCacheFile { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                return ExecuteCore();
+            }
+            catch (Exception ex)
+            {
+                LogException(ex);
+                return false;
+            }
+        }
+
+        private void LogException(Exception ex)
+        {
+            var agg = ex as AggregateException;
+            if (agg != null)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    LogException(inner);
+                }
+            }
+            else
+            {
+                Log.LogErrorFromException(ex, true);
+            }
+        }
+
+        private bool ExecuteCore()
+        {
+            var properties = new Dictionary<string, string>();
+            foreach (var prop in SetProperties.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var key = prop.Substring(0, prop.IndexOf('=')).Trim();
+                var value = prop.Substring(prop.IndexOf('=') + 1).Trim();
+                if (!string.IsNullOrEmpty(key))
+                {
+                    properties[key] = value;
+                }
+            }
+            var projectFiles = CandidateReferenceProjects
+                .Select(p => p.GetMetadata("FullPath"))
+                .ToArray();
+            var propertyArray = new IDictionary[projectFiles.Length];
+            for (int i = 0; i < projectFiles.Length; i++)
+            {
+                propertyArray[i] = properties;
+            }
+            var removePropertiesArray = Enumerable.Repeat((IList<string>)UndefineProperties.Split(new[] { ';' }).Select(p => p.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToArray(), propertyArray.Length).ToArray();
+            BuildEngineResult result = BuildEngine3.BuildProjectFilesInParallel(
+                projectFiles,
+                Enumerable.Repeat("GetTargetPath", projectFiles.Length).ToArray(),
+                propertyArray,
+                removePropertiesArray,
+                new string[projectFiles.Length],
+                true
+            );
+            if (!result.Result)
+            {
+                Log.LogError("Building 'GetTargetPath' Failed.");
+                return false;
+            }
+            var assemblyNameToProject = new Dictionary<string, LiveReferenceData>();
+            for (int i = 0; i < projectFiles.Length; i++)
+            {
+                string projectFile = projectFiles[i];
+                IDictionary<string, ITaskItem[]> targetOutputs = result.TargetOutputsPerProject[i];
+                ITaskItem targetPath = targetOutputs["GetTargetPath"].First();
+                string assemblyName = targetPath.GetMetadata("FileName");
+                assemblyNameToProject[assemblyName] = new LiveReferenceData
+                {
+                    Project = projectFile,
+                    TargetPath = targetPath.GetMetadata("FullPath")
+                };
+            }
+            File.WriteAllText(LiveReferenceCacheFile, JsonConvert.SerializeObject(assemblyNameToProject, Formatting.Indented));
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
+++ b/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.SourceIndexer.Tasks</RootNamespace>
+    <AssemblyName>Microsoft.SourceIndexer.Tasks</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Extensions.cs" />
+    <Compile Include="GenerateLiveReferenceCache.cs" />
+    <Compile Include="ResolveLivePackageReferences.cs" />
+    <Compile Include="SelectProjects.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Conversion.v4.0" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.Targets" />
+</Project>

--- a/src/Microsoft.SourceIndexer.Tasks/ResolveLivePackageReferences.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/ResolveLivePackageReferences.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.SourceIndexer.Tasks
+{
+    public class ResolveLivePackageReferences : Task
+    {
+        [Required]
+        public ITaskItem[] References { get; set; }
+
+        public string AdditionalAssemblyReferences { get; set; } = string.Empty;
+
+        [Required]
+        public string LiveReferenceCacheFile { get; set; }
+
+        [Output]
+        public ITaskItem[] ReferencePaths { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                return ExecuteCore();
+            }
+            catch (Exception ex)
+            {
+                LogException(ex);
+                return false;
+            }
+        }
+
+        private void LogException(Exception ex)
+        {
+            var agg = ex as AggregateException;
+            if (agg != null)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    LogException(inner);
+                }
+            }
+            else
+            {
+                Log.LogErrorFromException(ex, true);
+            }
+        }
+
+        private bool ExecuteCore()
+        {
+            var assemblyNameToProjectFile =
+                JsonConvert.DeserializeObject<Dictionary<string, LiveReferenceData>>(File.ReadAllText(LiveReferenceCacheFile));
+            var referencePaths = new List<ITaskItem>();
+            var referencedProjects = new List<LiveReferenceData>();
+            foreach (var reference in References)
+            {
+                var assemblyName = reference.GetMetadata("FileName");
+                LiveReferenceData referenceData;
+                if (assemblyNameToProjectFile.TryGetValue(assemblyName, out referenceData))
+                {
+                    referencedProjects.Add(referenceData);
+                }
+                else
+                {
+                    referencePaths.Add(reference);
+                }
+            }
+            var additionalAssemblyReferences =
+                AdditionalAssemblyReferences.Split(';').Where(s => !string.IsNullOrEmpty(s)).ToList();
+            foreach (var assemblyName in additionalAssemblyReferences)
+            {
+                referencedProjects.Add(assemblyNameToProjectFile[assemblyName]);
+            }
+            var projectsToBuild = new List<string>();
+            foreach (var liveReference in referencedProjects)
+            {
+                if (!File.Exists(liveReference.TargetPath))
+                {
+                    Log.LogMessage(MessageImportance.Normal, "Reference '{0}' doesn't exist. It will be built.", liveReference.TargetPath);
+                    projectsToBuild.Add(liveReference.Project);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Normal, "Reference '{0}' exists", liveReference.TargetPath);
+                }
+            }
+            BuildEngineResult result = BuildEngine3.BuildProjectFilesInParallel(
+                projectsToBuild.ToArray(),
+                "Build",
+                new Dictionary<string, string>(),
+                new[] {"CustomAfterBuildCommonTargets"},
+                null,
+                false
+            );
+            if (!result.Result)
+            {
+                Log.LogError("Failed to resolve references.");
+                return false;
+            }
+            referencePaths.AddRange(referencedProjects.Select(p => new TaskItem(p.TargetPath)));
+            ReferencePaths = referencePaths.ToArray();
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.SourceIndexer.Tasks/SelectProjects.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/SelectProjects.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace ClassLibrary
+{
+    public class SelectProjects : Task
+    {
+        [Required]
+        public ITaskItem[] Repositories { get; set; }
+
+        [Output]
+        public ITaskItem[] SelectedProjects { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                ExecuteCore();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex, true);
+                return false;
+            }
+        }
+
+        private void ExecuteCore()
+        {
+            var matcherType = Type.GetType("Microsoft.Build.Shared.FileMatcher, Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            var getFilesFunction = matcherType.GetTypeInfo()
+                    .GetMethod("GetFiles", BindingFlags.NonPublic | BindingFlags.Static, null, new Type[]{typeof(string), typeof(string)}, new ParameterModifier[0]);
+
+            var selectedProjects = new List<ITaskItem>();
+            foreach (var repository in Repositories)
+            {
+                var projects = repository.GetMetadata("Projects");
+                var localPath = repository.GetMetadata("LocalPath");
+                foreach (var projectItemSpec in projects.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var trimmed = projectItemSpec.Trim();
+                    if (!string.IsNullOrEmpty(trimmed))
+                    {
+                        var itemSpec = trimmed;
+                        var files = (string[])getFilesFunction.Invoke(null, new object[] {localPath, itemSpec});
+                        foreach (var file in files)
+                        {
+                        selectedProjects.Add(new TaskItem(localPath + file));
+                        }
+                    }
+                }
+            }
+            SelectedProjects = selectedProjects.OrderBy(i => i.GetMetadata("Identity")).ToArray();
+            Log.LogMessage("Selected Projects:");
+            foreach (var project in SelectedProjects)
+            {
+                Log.LogMessage(project.GetMetadata("FullPath"));
+            }
+        }
+    }
+}

--- a/src/Microsoft.SourceIndexer.Tasks/project.json
+++ b/src/Microsoft.SourceIndexer.Tasks/project.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable"
+  },
+  "dependencies": {},
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "Newtonsoft.Json": "9.0.1"
+      }
+    }
+  },
+  "runtimes": {
+    "win": { }
+  }
+}

--- a/src/index/SourceIndex.targets
+++ b/src/index/SourceIndex.targets
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);0433;1685</NoWarn>
+  </PropertyGroup>
+  <Target Name="FixProjectReferencesForSourceIndex" BeforeTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <ProjectReference>
+        <UndefineProperties>%(UndefineProperties);CustomAfterBuildCommonTargets</UndefineProperties>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+  <UsingTask TaskName="ResolveLivePackageReferences" AssemblyFile="$(SourceIndexerTasksAssembly)"/>
+  <Target Name="RewritePackageReferences" AfterTargets="ResolveNuGetPackages;FilterTargetingPackResolvedNugetPackages"
+          Condition="'$(IsReferenceAssembly)' != 'true'">
+    <ItemGroup>
+      <Reference Remove="@(_ReferenceFromPackage)"/>
+      <_ReferenceToResolve Include="@(_ReferenceFromPackage)" Exclude="@(PackageReferencesToRemove)"/>
+    </ItemGroup>
+    <ResolveLivePackageReferences
+      References="@(_ReferenceToResolve)"
+      AdditionalAssemblyReferences="mscorlib;System.Private.CoreLib"
+      LiveReferenceCacheFile="$(LiveReferenceCacheFile)">
+      <Output TaskParameter="ReferencePaths" ItemName="ReferencePath"/>
+    </ResolveLivePackageReferences>
+  </Target>
+</Project>

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -5,30 +5,31 @@
     <WhatIf Condition="'$(WhatIf)' != 'true'">false</WhatIf>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)repositories.props" />
-  
+
   <ItemDefinitionGroup>
     <Repository>
+      <Branch>master</Branch>
       <LocalPath>$(RepositoryPath)%(Identity)/</LocalPath>
-      <ServerPath>%(Url)/tree/master/</ServerPath>
+      <ServerPath>%(Url)/tree/%(Branch)/</ServerPath>
     </Repository>
   </ItemDefinitionGroup>
-  
+
   <Target Name="EnsurePreconditions">
     <Error Condition="'$(OS)' != 'Windows_NT'" Text="This tool can only be run on Windows_NT."/>
   </Target>
-  
+
   <Target Name="Clean">
     <RemoveDir Directories="$(OutDir)"/>
   </Target>
-  
+
   <Target Name="PrepareOutput">
     <MakeDir Condition="!Exists('$(OutDir)')" Directories="$(OutDir)"/>
     <MakeDir Condition="!Exists('$(RepositoryPath)')" Directories="$(RepositoryPath)"/>
   </Target>
-  
+
   <Target Name="Clone" DependsOnTargets="PrepareOutput" Outputs="%(Repository.Identity)">
     <PropertyGroup>
-      <CloneCommand>git clone %(Repository.Url).git --depth 1 %(LocalPath)</CloneCommand>
+      <CloneCommand>git clone %(Repository.Url).git --depth 1 -b %(Branch) --single-branch %(LocalPath)</CloneCommand>
     </PropertyGroup>
     <Exec Condition="!Exists('%(Repository.LocalPath)')" Command="$(CloneCommand)" />
     <Exec Command="git rev-parse HEAD 2>&amp;1" WorkingDirectory="%(Repository.LocalPath)" ConsoleToMSBuild="true">
@@ -41,67 +42,30 @@
     </ItemGroup>
   </Target>
 
+  <UsingTask TaskName="SelectProjects" AssemblyFile="$(SourceIndexerTasksAssembly)"/>
   <Target Name="SelectProjects" DependsOnTargets="Clone" Outputs="@(SourceProject)">
     <SelectProjects Repositories="@(ClonedRepository)">
       <Output TaskParameter="SelectedProjects" ItemName="SourceProject"/>
     </SelectProjects>
   </Target>
-  <UsingTask TaskName="SelectProjects" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <Repositories ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true"/>
-      <SelectedProjects ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System"/>
-      <Using Namespace="System.Collections.Generic"/>
-      <Using Namespace="System.IO"/>
-      <Using Namespace="System.Linq"/>
-      <Using Namespace="System.Reflection"/>
-      <Using Namespace="Microsoft.Build.Framework"/>
-      <Code>
-      <![CDATA[
-      var matcherType = Type.GetType("Microsoft.Build.Shared.FileMatcher, Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-      var getFilesFunction = matcherType.GetMethod("GetFiles", BindingFlags.NonPublic | BindingFlags.Static, null, CallingConventions.Any, new Type[]{typeof(string), typeof(string)}, new ParameterModifier[0]);
-      
-      var selectedProjects = new List<ITaskItem>();
-      foreach (var repository in Repositories)
-      {
-        var projects = repository.GetMetadata("Projects");
-        var localPath = repository.GetMetadata("LocalPath");
-        foreach (var projectItemSpec in projects.Split(new char[]{';'}, StringSplitOptions.RemoveEmptyEntries))
-        {
-          var trimmed = projectItemSpec.Trim();
-          if (!string.IsNullOrEmpty(trimmed))
-          {
-            var itemSpec = trimmed;
-            var files = (string[])getFilesFunction.Invoke(null, new object[] {localPath, itemSpec});
-            foreach (var file in files)
-            {
-              selectedProjects.Add(new TaskItem(localPath + file));
-            }
-          }
-        }
-      }
-      SelectedProjects = selectedProjects.OrderBy(i => i.GetMetadata("Identity")).ToArray();
-      Log.LogMessage("Selected Projects:");
-      foreach (var project in SelectedProjects)
-      {
-        Log.LogMessage(project.GetMetadata("FullPath"));
-      }
-      ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-  
+
   <Target Name="Validate" DependsOnTargets="SelectProjects">
     <Error Condition="!Exists('%(SourceProject.Identity)')" Text="Expected File '%(SourceProject.FullPath)' does not exist." Code="SB001"/>
   </Target>
-  
+
   <Target Name="Prepare" DependsOnTargets="Validate" Outputs="%(ClonedRepository.Identity)">
     <PropertyGroup>
       <PrepareCommand>$([System.String]::Copy('%(ClonedRepository.PrepareCommand)').Trim())</PrepareCommand>
     </PropertyGroup>
     <Exec Command="cmd /c &quot;$(PrepareCommand)&quot;" WorkingDirectory="%(ClonedRepository.LocalPath)" />
+  </Target>
+
+  <UsingTask TaskName="GenerateLiveReferenceCache" AssemblyFile="$(SourceIndexerTasksAssembly)"/>
+  <Target Name="CacheLiveReferencePaths" DependsOnTargets="Prepare">
+    <GenerateLiveReferenceCache
+      CandidateReferenceProjects="@(SourceProject)"
+      LiveReferenceCacheFile="$(OutDir)reference-cache.json"
+      />
   </Target>
 
   <Target Name="BuildGenerator">
@@ -110,7 +74,7 @@
     </MSBuild>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="BuildGenerator;Prepare">
+  <Target Name="Build" DependsOnTargets="BuildGenerator;Prepare;CacheLiveReferencePaths">
     <Error Condition="!Exists('$(HtmlGeneratorExePath)')" Text="Html generator executable not found."/>
     <RemoveDuplicates Inputs="@(SourceProject)">
       <Output TaskParameter="Filtered" ItemName="_FilteredProject"/>
@@ -121,11 +85,13 @@
       <SourceIndexCmd>$(HtmlGeneratorExePath)</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /out:$(OutDir)index/</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /in:$(OutDir)index.list</SourceIndexCmd>
-      <SourceIndexCmd>$(SourceIndexCmd) /p:SourceIndex=true</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /p:LiveReferenceCacheFile=$(OutDir)reference-cache.json</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /p:SourceIndexerTasksAssembly=$(SourceIndexerTasksAssembly)</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /p:CustomAfterBuildCommonTargets=$(MSBuildThisFileDirectory)/SourceIndex.targets</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepository -> ' /serverPath:"%(LocalPath)=%(ServerPath)"', '')</SourceIndexCmd>
     </PropertyGroup>
     <Exec Command="$(SourceIndexCmd)"/>
   </Target>
-  
+
   <Target Name="Rebuild" DependsOnTargets="Clean;Build"/>
 </Project>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -11,13 +11,13 @@
       </Projects>
       <PrepareCommand>
         sync
-        build-managed -binaries
       </PrepareCommand>
     </Repository>
     <Repository Include="coreclr">
       <Url>https://github.com/dotnet/coreclr</Url>
       <Projects>
-        src/mscorlib/System.Private.CoreLib.csproj
+        src/mscorlib/System.Private.CoreLib.csproj;
+        src/mscorlib/facade/mscorlib.csproj;
       </Projects>
       <PrepareCommand>sync</PrepareCommand>
     </Repository>

--- a/src/source-indexer.sln
+++ b/src/source-indexer.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SourceIndexer.Tasks", "Microsoft.SourceIndexer.Tasks\Microsoft.SourceIndexer.Tasks.csproj", "{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D86D28A-FEB9-4561-8EA8-D3C3BB409FB3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This change uses the new extension point in buildtools to extend the build to replace nuget package references with pseudo ProjectReferences.
