### PR TITLE
Unblock official build on VS 15.5+

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -33,9 +33,16 @@
 
   <Target Name="Clone" DependsOnTargets="PrepareOutput" Outputs="%(Repository.Identity)">
     <PropertyGroup>
-      <CloneCommand>git clone %(Repository.Url).git --depth 1 -b %(Branch) --single-branch %(LocalPath)</CloneCommand>
+      <CloneCommand>git clone %(Repository.Url).git -b %(Branch) --single-branch</CloneCommand>
+      <CloneCommand Condition="'%(Repository.OldCommit)' == ''">$(CloneCommand) --depth 1</CloneCommand>
+      <CloneCommand>$(CloneCommand) %(Repository.LocalPath)</CloneCommand>
+
+      <CheckoutCommand Condition="'%(Repository.OldCommit)' != ''">git -C %(Repository.LocalPath) checkout %(Repository.OldCommit)</CheckoutCommand>
+
+      <CloneExists Condition="Exists('%(Repository.LocalPath)')">true</CloneExists>
     </PropertyGroup>
-    <Exec Condition="!Exists('%(Repository.LocalPath)')" Command="$(CloneCommand)" />
+    <Exec Condition="'$(CloneExists)' != 'true'" Command="$(CloneCommand)" />
+    <Exec Condition="'$(CloneExists)' != 'true' and  '$(CheckoutCommand)' != ''" Command="$(CheckoutCommand)" />
     <Exec Command="git rev-parse HEAD 2>&amp;1" WorkingDirectory="%(Repository.LocalPath)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitHash"/>
     </Exec>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -34,6 +34,7 @@
     <Repository Include="msbuild">
       <Url>https://github.com/Microsoft/msbuild</Url>
       <Branch>master</Branch>
+      <OldCommit>91c86a746b312fce1aba31f8fb8540e949c11a01</OldCommit>
       <Projects>
         build/**/*.csproj;
         build/**/*.vbproj;


### PR DESCRIPTION
Unblocks the source-indexer build: https://github.com/dotnet/core-eng/issues/2728

Note: MSBuild is frozen to a LKG commit from a few months ago. Its new build system freezes when I run it in this VSTS build, so I'm still looking into that.

Brings in this submodule PR: https://github.com/dotnet/SourceBrowser/pull/4

---

Old description:

> It would be better to remove this lookup completely (as mentioned in https://github.com/dotnet/core-eng/issues/2728), but this should at least unblock the builds for now by continuing the current runtime type lookup pattern.
> 
> I didn't have the exact VS version to try this out against, only a `15.6.0 Preview 3.0` vs. the build's `15.5.180.51428`, but it looks like the signature has only had one change after `func15`:
> https://github.com/Microsoft/msbuild/blame/master/src/Shared/FileMatcher.cs#L1692-L1698
> https://github.com/Microsoft/msbuild/blame/0c3e87cbbfc1c32c29029e61b985fda2f3714983/src/Shared/FileMatcher.cs#L1402-L1407