### PR TITLE
Override the solution explorer with an empty one

### DIFF
--- a/src/index/overwrite/index/SolutionExplorer.html
+++ b/src/index/overwrite/index/SolutionExplorer.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html><head><title>Solution Explorer</title><link rel="stylesheet" href="styles.css" /><script src="scripts.js"></script></head>
+<body class="solutionExplorerBody">
+    <div>
+        <div class="note">
+            Enter a type or member name or <a href="/#q=assembly%20" target="_top" class="blueLink" onclick="populateSearchBox('assembly '); return false;">filter the assembly list</a>.
+        </div>
+    </div>
+</body></html>


### PR DESCRIPTION
The generated solution explorer is a 35KB file, it takes browsers way too long to render the tree view from that.