### PR TITLE
Several source-indexer fixes

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -87,10 +87,12 @@
     <PropertyGroup>
       <SourceIndexCmd>$(HtmlGeneratorExePath)</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /nobuiltinfederations</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /noplugins</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /out:$(OutDir)index/</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /in:$(OutDir)index.list</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepository -> ' /serverPath:"%(LocalPath)=%(ServerPath)"', '')</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /p:TargetGroup=netcoreapp</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /p:RunApiCompat=false</SourceIndexCmd>
     </PropertyGroup>
     <Exec Command="$(SourceIndexCmd)" LogStandardErrorAsError="false"/>
     <Copy SourceFiles="@(OverwriteFiles)" DestinationFiles="@(OverwriteFiles -> '$(OutDir)index/%(RecursiveDir)%(Filename)%(Extension)')"/>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -11,7 +11,7 @@
         src/*/src/*.vbproj;
       </Projects>
       <PrepareCommand>
-        $(VsDevCmd) &amp; build -SkipTests /p:buildnative=false
+        $(VsDevCmd) &amp; build -SkipTests /p:buildnative=false -- /p:BuildPackages=false
       </PrepareCommand>
     </Repository>
     <Repository Include="corefxlab">
@@ -20,7 +20,7 @@
         src/**/*.csproj;
       </Projects>
       <PrepareCommand>
-        $(VsDevCmd) &amp; build
+        $(VsDevCmd) &amp; build -SkipTests
       </PrepareCommand>
     </Repository>
     <Repository Include="coreclr">
@@ -38,11 +38,11 @@
       <DeepClone>true</DeepClone>
       <Projects>
         src/**/*.csproj;
-        src/**/*.vbproj;
       </Projects>
       <ExcludeProjects>
         src/Deprecated/**/*.csproj;
-        src/Deprecated/**/*.vbproj;
+        src/*UnitTests*/**/*.csproj;
+        src/Samples/**/*.csproj;
       </ExcludeProjects>
       <PrepareCommand>
         $(VsDevCmd) &amp; build -hostType Core
@@ -60,8 +60,7 @@
     <Repository Include="wcf">
       <Url>https://github.com/dotnet/wcf</Url>
       <Projects>
-        src/System.*/**/*.csproj;
-        src/System.*/**/*.vbproj;
+        src/System.*/src/*.csproj;
       </Projects>
       <PrepareCommand>
         $(VsDevCmd) &amp; build-managed -SkipTests


### PR DESCRIPTION
- Disable plugins.  They're not needed and are causing some exceptions.
- Disable API compat.  It's not needed and is resulting in a spew of failures in the error log.
- Disable building corefx packages.  They're not needed and suffer validation failures due to the partial build.
- Disable running corefxlab tests as part of build.
- Disable searching for WCF and MSBuild .vbprojs, as there aren't any.
- Disable including MSBuild test and sample projects, as they're not needed in the index.

cc: @alexperovich, @danmosemsft 