### PR TITLE
Comment out iot addition that's breaking the build

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -53,6 +53,7 @@
         $(VsDevCmd) &amp; build -skiptests -skipnative -windowsmscorlib
       </PrepareCommand>
     </Repository>
+<!-- TODO: Uncomment when it no longer breaks the build
     <Repository Include="iot">
       <Url>https://github.com/dotnet/iot</Url>
       <Projects>
@@ -62,6 +63,7 @@
         $(VsDevCmd) &amp; build
       </PrepareCommand>
     </Repository>
+-->
     <Repository Include="msbuild">
       <Url>https://github.com/Microsoft/msbuild</Url>
       <Branch>master</Branch>


### PR DESCRIPTION
Build failing with:
```
src\index\index.proj(58,5): Error : Illegal characters in path.
   at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
   at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
   at System.IO.Path.GetFullPath(String path)
   at Microsoft.SourceIndexer.Tasks.SelectProjects.<>c__DisplayClass10_0.<EvaluateItemInclude>b__3(String relative) in F:\a\_work\7\s\src\Microsoft.SourceIndexer.Tasks\SelectProjects.cs:line 61
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.<ExceptIterator>d__73`1.MoveNext()
   at Microsoft.SourceIndexer.Tasks.SelectProjects.ExecuteCore() in F:\a\_work\7\s\src\Microsoft.SourceIndexer.Tasks\SelectProjects.cs:line 72
   at Microsoft.SourceIndexer.Tasks.SelectProjects.Execute() in F:\a\_work\7\s\src\Microsoft.SourceIndexer.Tasks\SelectProjects.cs:line 23

Process 'msbuild.exe' exited with code '1'.
```
cc: @danmosemsft, @alexperovich 