### PR TITLE
Fix build when path contains spaces

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -35,7 +35,7 @@
     <PropertyGroup>
       <CloneCommand>git clone %(Repository.Url).git -b %(Branch) --single-branch</CloneCommand>
       <CloneCommand Condition="'%(Repository.OldCommit)' == '' and '%(Repository.DeepClone)' != 'true'">$(CloneCommand) --depth 1</CloneCommand>
-      <CloneCommand>$(CloneCommand) %(Repository.LocalPath)</CloneCommand>
+      <CloneCommand>$(CloneCommand) "%(Repository.LocalPath)"</CloneCommand>
 
       <CheckoutCommand Condition="'%(Repository.OldCommit)' != ''">git -C %(Repository.LocalPath) checkout %(Repository.OldCommit)</CheckoutCommand>
 
@@ -85,12 +85,12 @@
     <RemoveDir Directories="$(OutDir)index/"/>
     <WriteLinesToFile Lines="@(_FilteredProject -> '%(FullPath)')" File="$(OutDir)index.list" Overwrite="true"/>
     <PropertyGroup>
-      <SourceIndexCmd>$(HtmlGeneratorExePath)</SourceIndexCmd>
+      <SourceIndexCmd>"$(HtmlGeneratorExePath)"</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /donotincludereferencedprojects</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /nobuiltinfederations</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /noplugins</SourceIndexCmd>
-      <SourceIndexCmd>$(SourceIndexCmd) /out:$(OutDir)index/</SourceIndexCmd>
-      <SourceIndexCmd>$(SourceIndexCmd) /in:$(OutDir)index.list</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /out:"$(OutDir)index/"</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd) /in:"$(OutDir)index.list"</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepository -> ' /serverPath:"%(LocalPath)=%(ServerPath)"', '')</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /p:TargetGroup=netcoreapp</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /p:RunApiCompat=false</SourceIndexCmd>


### PR DESCRIPTION
Currently, the build will fail if the repository path contains a space.  
This PR fixes that by adding quotes around the paths.