### PR TITLE
Update dotnet/runtime build invocation

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -28,7 +28,7 @@
 /*
       </SparseCheckout>
       <PrepareCommand>
-        src\coreclr\build.cmd -skiptests -skipnative -linuxmscorlib &amp;&amp; libraries.cmd /p:BuildNative=false /p:BuildPackages=false -binarylog -os Linux
+        build.cmd -subsetcategory coreclr-libraries -subset corelib-all /p:BuildNative=false /p:BuildPackages=false -binarylog -os Linux
       </PrepareCommand>
     </Repository>
     <Repository Include="winforms">


### PR DESCRIPTION
dotnet/runtime will remove the build helper scripts (coreclr.cmd, libraries.cmd, etc.) [soon](https://github.com/dotnet/runtime/pull/33756). Proactively updating the invocation here to prevent a break in the source-indexer.