### PR TITLE
Temporarily remove projects still using 3.1 SDK

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -52,15 +52,6 @@
         build
       </PrepareCommand>
     </Repository>
-    <Repository Include="machinelearning">
-      <Url>https://github.com/dotnet/machinelearning</Url>
-      <Projects>
-        src/**/*.csproj;
-      </Projects>
-      <PrepareCommand>
-        build -- /t:RestoreProjects
-      </PrepareCommand>
-    </Repository>
     <Repository Include="aspnetcore">
       <Url>https://github.com/dotnet/aspnetcore</Url>
       <Projects>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -52,40 +52,6 @@
         build
       </PrepareCommand>
     </Repository>
-    <Repository Include="corefxlab">
-      <Url>https://github.com/dotnet/corefxlab</Url>
-      <Projects>
-        src/**/*.csproj;
-      </Projects>
-      <PrepareCommand>
-        build -SkipTests "true"
-      </PrepareCommand>
-    </Repository>
-    <Repository Include="iot">
-      <Url>https://github.com/dotnet/iot</Url>
-      <Projects>
-        src/**/*.csproj;
-      </Projects>
-      <PrepareCommand>
-        build
-      </PrepareCommand>
-    </Repository>
-    <Repository Include="msbuild">
-      <Url>https://github.com/Microsoft/msbuild</Url>
-      <Branch>master</Branch>
-      <DeepClone>true</DeepClone>
-      <Projects>
-        src/**/*.csproj;
-      </Projects>
-      <ExcludeProjects>
-        src/Deprecated/**/*.csproj;
-        src/*UnitTests*/**/*.csproj;
-        src/Samples/**/*.csproj;
-      </ExcludeProjects>
-      <PrepareCommand>
-        powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore"
-      </PrepareCommand>
-    </Repository>
     <Repository Include="machinelearning">
       <Url>https://github.com/dotnet/machinelearning</Url>
       <Projects>
@@ -93,15 +59,6 @@
       </Projects>
       <PrepareCommand>
         build -- /t:RestoreProjects
-      </PrepareCommand>
-    </Repository>
-    <Repository Include="wcf">
-      <Url>https://github.com/dotnet/wcf</Url>
-      <Projects>
-        src/System.*/src/*.csproj;
-      </Projects>
-      <PrepareCommand>
-        powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore"
       </PrepareCommand>
     </Repository>
     <Repository Include="aspnetcore">


### PR DESCRIPTION
This can be reverted when https://github.com/dotnet/core-eng/issues/9537 is better addressed.