### PR TITLE
Add dotnet/performance to repositories.props

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -37,7 +37,7 @@
       </PrepareCommand>
     </Repository>
     <Repository Include="msbuild">
-      <Url>https://github.com/Microsoft/msbuild</Url>
+      <Url>https://github.com/dotnet/msbuild</Url>
       <Branch>master</Branch>
       <DeepClone>true</DeepClone>
       <PrepareCommand>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -69,5 +69,11 @@
         $(ArcadeBuildCmd)
       </PrepareCommand>
     </Repository>
+    <Repository Include="performance">
+      <Url>https://github.com/dotnet/performance</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
+      </PrepareCommand>
+    </Repository>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This resolves https://github.com/dotnet/source-indexer/issues/63. I also fixed the repo url for msbuild while I was here.