### PR TITLE
Catch SDK installation failures on unreasonable versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     displayName: Use .Net Core sdk 2.1.805
     inputs:
       version: 2.1.805
-  
+
   - script: |
       dotnet tool restore
       dotnet script deployment/AllowPrereleaseSdks.csx
@@ -67,7 +67,7 @@ jobs:
 
      ls -Recurse -Include global.json | %{
        $v = $_ | Get-Content -Raw | ConvertFrom-Json | %{ if ($_.tools.dotnet) {$_.tools.dotnet} else {$_.sdk.version} }
-       $isSensibleVersion = $v.Split('.')[0] -as [int] -le 6
+       $isSensibleVersion = $v.Split('.')[0] -as [int] -le 30
        Write-Host "Installing .NET CLI version $v from $_"
        try
        {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,18 @@ jobs:
 
      ls -Recurse -Include global.json | %{
        $v = $_ | Get-Content -Raw | ConvertFrom-Json | %{ if ($_.tools.dotnet) {$_.tools.dotnet} else {$_.sdk.version} }
-       if ($v -and (-not $v.EndsWith('-*'))) {
-        Write-Host "Installing .NET CLI version $v from $_"
-        & $installScript -Version $v -InstallDir $installDir
+       $isSensibleVersion = $v.Split('.')[0] -as [int] -le 6
+       Write-Host "Installing .NET CLI version $v from $_"
+       try
+       {
+         & $installScript -Version $v -InstallDir $installDir -NoPath
        }
-     }
+       catch
+       {
+         Write-Host "Unable to install Version $v"
+         if ($isSensibleVersion) throw
+       }
+      }
     displayName: 'Install Required Versions of .NET Core'
 
   - task: VSBuild@1
@@ -185,5 +192,3 @@ jobs:
 
   - publish: bin/repo
     artifact: repo-logs
-
-


### PR DESCRIPTION
This tries to work around tests in WCF asking for version 99.99.99 of the SDK.