### PR TITLE
Switch to 1ES R&D pools on main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ jobs:
   displayName: Build Source Index
 
   pool:
-    name: NetCoreInternal-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2019
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
   timeoutInMinutes: 360
 


### PR DESCRIPTION
Switch to the 1ES R&D pools on `main`.