### PR TITLE
Tweak CG to ignore cloned repositories

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ jobs:
     displayName: Check Allow Prerelease Sdks
 
   - task: DotNetCoreCLI@2
+    displayName: dotnet restore
     inputs:
       command: custom
       custom: restore
@@ -54,6 +55,7 @@ jobs:
         **\*.sln
 
   - task: DotNetCoreCLI@2
+    displayName: dotnet build
     inputs:
       command: 'build'
       projects: |
@@ -62,6 +64,7 @@ jobs:
       arguments: '/p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages'
   
   - task: NuGetCommand@2
+    displayName: NuGet push
     inputs:
       command: 'push'
       packagesToPush: '$(Build.ArtifactStagingDirectory)/packages/*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,6 @@ jobs:
       arguments: '/p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages'
   
   - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      ignoreDirectories: bin/repo
 
   - task: NuGetCommand@2
     displayName: NuGet push

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -240,3 +240,7 @@ jobs:
   - publish: bin/repo
     artifact: repo-logs
     condition: always()
+
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      ignoreDirectories: bin/repo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,10 @@ jobs:
         src\SourceBrowser\SourceBrowser.sln
       arguments: '/p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages'
   
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      ignoreDirectories: bin/repo
+
   - task: NuGetCommand@2
     displayName: NuGet push
     inputs:
@@ -240,7 +244,3 @@ jobs:
   - publish: bin/repo
     artifact: repo-logs
     condition: always()
-
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      ignoreDirectories: bin/repo


### PR DESCRIPTION
Tweak the component governance scan configuration to scan only build data from source-indexer. This has the benefit of also ignoring data coming from the cloned and indexed repositories. Those repositories are managed separately. Also, their code here is only indexed, not executed.