### PR TITLE
Add .NET 6 to the build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,14 +32,15 @@ jobs:
       Contents: '**/*'
 
   - task: UseDotNet@2
-    displayName: Use .Net Core sdk 3.1.201
+    displayName: Install .NET Sdk
     inputs:
-      version: 3.1.201
+      useGlobalJson: true
 
   - task: UseDotNet@2
-    displayName: Use .Net Core sdk 2.1.805
+    displayName: Install .NET 3.1 runtime
     inputs:
-      version: 2.1.805
+      packageType: runtime
+      version: 3.1.x
 
   - script: |
       dotnet tool restore

--- a/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
         public bool FileExists(string name)
         {
             name = name.ToLowerInvariant();
-            var blob = container.GetBlobClient(name);
+            BlobClient blob = container.GetBlobClient(name);
             
             return blob.Exists();
         }
@@ -46,21 +46,20 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
         public Stream OpenSequentialReadStream(string name)
         {
             name = name.ToLowerInvariant();
-            var blob = container.GetBlobClient(name);
-            return blob.Download().Value.Content;
+            BlobClient blob = container.GetBlobClient(name);
+            return blob.OpenRead();
         }
 
         public IEnumerable<string> ReadLines(string name)
         {
             name = name.ToLowerInvariant();
-            var blob = container.GetBlobClient(name);
-            using (var stream = blob.Download().Value.Content)
-            using (var reader = new StreamReader(stream))
+            BlobClient blob = container.GetBlobClient(name);
+            using Stream stream = blob.OpenRead();
+            using StreamReader reader = new (stream);
+
+            while (!reader.EndOfStream)
             {
-                while (!reader.EndOfStream)
-                {
-                    yield return reader.ReadLine();
-                }
+                yield return reader.ReadLine();
             }
         }
     }

--- a/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
@@ -1,46 +1,18 @@
-﻿using System;
+﻿using Azure.Storage.Blobs;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using Azure.Core.Pipeline;
-using Azure.Storage;
-using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
 
 namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
     public class AzureBlobFileSystem : IFileSystem
     {
-        private class AnonContainerClient : BlobContainerClient
-        {
-            public override Uri Uri { get; }
-            protected override HttpPipeline Pipeline { get; }
-
-            public AnonContainerClient(string uri)
-            {
-                Uri = new Uri(uri);
-                Pipeline = HttpPipelineBuilder.Build(new BlobClientOptions());
-            }
-
-            public override BlobClient GetBlobClient(string blobName)
-            {
-                return (BlobClient)typeof(BlobClient).GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.ToString() == "Void .ctor(System.Uri, Azure.Core.Pipeline.HttpPipeline)").Invoke(new object[] { AppendToPath(this.Uri, blobName), this.Pipeline });
-            }
-
-            private static Uri AppendToPath(Uri uri, string segment)
-            {
-                UriBuilder uriBuilder = new UriBuilder(uri);
-                string path = uriBuilder.Path;
-                uriBuilder.Path = uriBuilder.Path + (path.Length == 0 || path[path.Length - 1] != '/' ? "/" : "") + segment;
-                return uriBuilder.Uri;
-            }
-        }
-
         private readonly BlobContainerClient container;
+
         public AzureBlobFileSystem(string uri)
         {
-            container = new AnonContainerClient(uri);
+            container = new BlobContainerClient(new Uri(uri));
         }
 
         public bool DirectoryExists(string name)
@@ -57,25 +29,18 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 dirName += "/";
             }
 
-            return container.GetBlobsByHierarchy("/", new GetBlobsOptions
-            {
-                Prefix = dirName,
-            }).Select(res => res.Value).Where(item => item.IsBlob).Select(item => item.Blob.Name).ToList();
+            return container.GetBlobsByHierarchy(prefix: dirName)
+                .Where(item => item.IsBlob)
+                .Select(item => item.Blob.Name)
+                .ToList();
         }
 
         public bool FileExists(string name)
         {
             name = name.ToLowerInvariant();
             var blob = container.GetBlobClient(name);
-            try
-            {
-                blob.GetProperties();
-                return true;
-            }
-            catch (StorageRequestFailedException ex) when (string.Equals(ex.ErrorCode, "BlobNotFound"))
-            {
-                return false;
-            }
+            
+            return blob.Exists();
         }
 
         public Stream OpenSequentialReadStream(string name)

--- a/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
+++ b/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Nightly build [20220803.1](https://dev.azure.com/dnceng/internal/_build/results?buildId=1920322&view=results) failed because the build machines do not include .NET 6 by default. This adds it explicitly to the pipeline definition, and cleans-up use of older SDKs.

Test build happening in [20220803.3](https://dev.azure.com/dnceng/internal/_build/results?buildId=1921369&view=results).