### PR TITLE
Add EF Core

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -57,6 +57,10 @@
       <RepoName>dotnet-aspnetcore</RepoName>
       <Url>https://github.com/dotnet/aspnetcore</Url>
     </RepositoryV2>
+    <RepositoryV2 Include="efcore">
+      <RepoName>dotnet-efcore</RepoName>
+      <Url>https://github.com/dotnet/efcore</Url>
+    </RepositoryV2>
     <Repository Include="performance">
       <Url>https://github.com/dotnet/performance</Url>
       <PrepareCommand>


### PR DESCRIPTION
The AzDo stage was already added to EF in https://github.com/dotnet/efcore/pull/30303/files

Fixes https://github.com/dotnet/source-indexer/issues/56