### PR TITLE
Update structured log viewer to latest

### DIFF
--- a/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
+++ b/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.858" />
   </ItemGroup>
 
 

--- a/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
@@ -71,7 +71,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.858" />
     <PackageReference Include="GuiLabs.Language.Xml" Version="1.2.46" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.10.230" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Fix aspnetcore CI builds

`Unhandled exception. System.NotSupportedException: Unsupported log file format. Latest supported version is 16, the log file has version 17.`

This version supports 17
