### PR TITLE
Update projects to net8.0 and move to Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="src\SourceBrowser\src\Directory.Packages.props" />
+</Project>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains the code for building http://source.dot.net
 This repo uses https://github.com/KirillOsenkov/SourceBrowser (with a few additions here https://github.com/dotnet/SourceBrowser/tree/source-indexer) to index the dotnet sources and produce a navigatable and searchable website containing the full source code. This includes code from the runtime, winforms, wpf, aspnetcore, and msbuild, among others. For a full list see here https://github.com/dotnet/source-indexer/blob/main/src/index/repositories.props.
 
 ## Build Prerequsites
-The build requires .NET core 6.0 and Visual Studio 2022 to build.
+The build requires .NET 8.0 and Visual Studio 2022 to build.
 
 ## Build
 The build will only work on windows because the source indexer executable is a .net framework executable.

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -47,10 +47,10 @@ stages:
         useGlobalJson: true
 
     - task: UseDotNet@2
-      displayName: Install .NET 6.0 runtime
+      displayName: Install .NET 8.0 runtime
       inputs:
         packageType: runtime
-        version: 6.0.x
+        version: 8.0.x
 
     - task: CodeQL3000Init@0
       displayName: CodeQL Initialize

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,10 +37,10 @@ jobs:
       useGlobalJson: true
 
   - task: UseDotNet@2
-    displayName: Install .NET 6.0 runtime
+    displayName: Install .NET 8.0 runtime
     inputs:
       packageType: runtime
-      version: 6.0.x
+      version: 8.0.x
 
   - script: |
       dotnet tool restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.302",
+    "version": "8.0.100",
     "rollForward": "major"
   }
 }

--- a/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
+++ b/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 </Project>

--- a/src/SourceBrowser/TestCode/Type.Forwardee/Type.Forwardee.csproj
+++ b/src/SourceBrowser/TestCode/Type.Forwardee/Type.Forwardee.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ProjectGuid>{A2B515A8-9468-4AF5-89CE-807902F03D79}</ProjectGuid>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <OutputType>Library</OutputType>

--- a/src/SourceBrowser/TestCode/Type.Forwarder.Reference/Type.Forwarder.Reference.csproj
+++ b/src/SourceBrowser/TestCode/Type.Forwarder.Reference/Type.Forwarder.Reference.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Configuration">
     <AssemblyName>Type.Forwarder</AssemblyName>
     <RootNamespace>Type.Forwarder</RootNamespace>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ProjectGuid>{F922C544-DC33-4C0B-837C-81A65EB37863}</ProjectGuid>
     <OutputType>Library</OutputType>
     <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/src/SourceBrowser/TestCode/Type.Forwarder/Type.Forwarder.csproj
+++ b/src/SourceBrowser/TestCode/Type.Forwarder/Type.Forwarder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ProjectGuid>{79AEDCEA-6D49-463D-B5B8-2DDF120C0247}</ProjectGuid>
     <OutputType>Library</OutputType>
     <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/src/SourceBrowser/TestCode/Type.Referencer/Type.Referencer.csproj
+++ b/src/SourceBrowser/TestCode/Type.Referencer/Type.Referencer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ProjectGuid>{C34D3731-2CE5-41C2-AFCC-A8A0545D2849}</ProjectGuid>
     <OutputType>Library</OutputType>
     <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
+++ b/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
@@ -1,23 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AssemblyName>BinLogParser</AssemblyName>
     <RootNamespace>Microsoft.SourceBrowser.BinLogParser</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NuGetVersionRoslyn>3.9.0-2.final</NuGetVersionRoslyn>
-  </PropertyGroup>
-
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.IO.Redist" Version="6.0.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.858" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
+    <PackageReference Include="MSBuild.StructuredLogger" />
   </ItemGroup>
 
 

--- a/src/SourceBrowser/src/BinLogToSln/BinLogToSln.csproj
+++ b/src/SourceBrowser/src/BinLogToSln/BinLogToSln.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <VersionPrefix>1.0.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBrowser/src/Common/Common.csproj
+++ b/src/SourceBrowser/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.SourceBrowser.Common</AssemblyName>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -9,8 +9,7 @@
     <DefineConstants>$(DefineConstants);NET472</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.IO.Redist" Version="6.0.0" NoWarn="NU1701" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 </Project>

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -1,0 +1,78 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- msbuild-->
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
+
+    <!-- roslyn -->
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+
+    <!-- roslyn analyzer -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+
+    <!-- test dependencies -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Shouldly" Version="4.0.3" />
+
+    <!-- other dependencies -->
+    <PackageVersion Include="LibGit2Sharp" Version="0.29.0" />
+    <PackageVersion Include="MSBuild.StructuredLogger" Version="2.1.858" />
+    <PackageVersion Include="ManagedEsent" Version="1.9.4" />
+    <PackageVersion Include="System.Reactive" Version="5.0.0" />
+    <PackageVersion Include="System.Composition" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+
+    <PackageVersion Include="System.Buffers" Version="4.5.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.3" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.10.230" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02" />
+
+    <PackageVersion Include="ExceptionAnalysis.Diagnostics" Version="1.0.0.39796" />
+    <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.46" />
+
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
+  </ItemGroup>
+
+  <!-- dependencies for dotnet/source-browser projects -->
+  <ItemGroup>
+      <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.0" />
+      <PackageVersion Include="Mono.Options" Version="6.6.0.161" />
+      <PackageVersion Include="SharpZipLib" Version="1.3.3" />
+      <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/SourceBrowser/src/GitGlyph/GitGlyph.csproj
+++ b/src/SourceBrowser/src/GitGlyph/GitGlyph.csproj
@@ -8,8 +8,8 @@
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/HtmlGenerator.Tests.csproj
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/HtmlGenerator.Tests.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <!-- FIXME -->
+    <NoWarn>$(NoWarn);VSTHRD002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
@@ -11,12 +11,13 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <NoWarn>$(NoWarn);VSTHRD200</NoWarn>
+    <!-- FIXME -->
+    <NoWarn>$(NoWarn);VSTHRD002</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <NuGetPackageId>SourceBrowser</NuGetPackageId>
     <NuSpecFile>$(MSBuildProjectDirectory)\$(NuGetPackageId).nuspec</NuSpecFile>
     <NuGetVersion>1.0.38</NuGetVersion>
-    <NuGetVersionRoslyn>4.2.0</NuGetVersionRoslyn>
   </PropertyGroup>
   <ItemGroup>
     <NuGetInput Include="$(MSBuildThisFile)" />
@@ -34,48 +35,46 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.3" />
+    <PackageReference Include="Microsoft.Build.Locator" />
 
-    <!-- All Dlls provided in the msbuild install, they need to have ExcludeAssets="runtime" on them -->
-    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.10.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.IO.Redist" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.NET.StringTools" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Memory" Version="4.5.5" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" ExcludeAssets="runtime" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Microsoft.NET.StringTools" />
+    <PackageReference Include="System.Buffers" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Numerics.Vectors" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Resources.Extensions" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="System.ValueTuple" />
 
-    <PackageReference Include="ExceptionAnalysis.Diagnostics" Version="1.0.0.39796" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="ExceptionAnalysis.Diagnostics" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.858" />
-    <PackageReference Include="GuiLabs.Language.Xml" Version="1.2.46" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.10.230" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <PackageReference Include="MSBuild.StructuredLogger" />
+    <PackageReference Include="GuiLabs.Language.Xml" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BinLogParser\BinLogParser.csproj" />

--- a/src/SourceBrowser/src/MEF/MEF.csproj
+++ b/src/SourceBrowser/src/MEF/MEF.csproj
@@ -8,14 +8,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedEsent" Version="1.9.4" />
-    <PackageReference Include="Microsoft.Build" Version="16.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="ManagedEsent" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.6.0" />
-    <PackageReference Include="System.Composition" Version="1.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+    <PackageReference Include="System.Composition" />
   </ItemGroup>
 </Project>

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/SourceIndexServer.Tests.csproj
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/SourceIndexServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,14 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
 
     <!-- Pin transitive dependency versions -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBrowser/src/SourceIndexServer/Helpers.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Helpers.cs
@@ -50,7 +50,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
                         default:
                             if (!context.Response.Headers.ContainsKey(key))
                             {
-                                context.Response.Headers.Add(key, values.ToArray());
+                                context.Response.Headers[key] = values.ToArray();
                             }
 
                             break;
@@ -64,7 +64,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
                     {
                         if (!context.Response.Headers.ContainsKey(key))
                         {
-                            context.Response.Headers.Add(key, values.ToArray());
+                            context.Response.Headers[key] = values.ToArray();
                         }
                     }
 

--- a/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
+++ b/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.SourceBrowser.SourceIndexServer</AssemblyName>
     <RootNamespace>Microsoft.SourceBrowser.SourceIndexServer</RootNamespace>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
   </ItemGroup>
 
 </Project>

--- a/src/UploadIndexStage1/UploadIndexStage1.csproj
+++ b/src/UploadIndexStage1/UploadIndexStage1.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <VersionPrefix>1.0.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In https://github.com/dotnet/arcade/pull/14172 we were seeing this issue:

```
Processing binlog artifacts/log/Debug/Build.binlog into solution at directory .source-index/stage1output
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
File name: 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at Microsoft.SourceBrowser.BinLogParser.BinLogCompilerInvocationsReader.<>c__DisplayClass1_0.<ExtractInvocations>b__0()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Microsoft.SourceBrowser.BinLogParser.BinLogCompilerInvocationsReader.ExtractInvocations(String binLogFilePath) in D:\a\_work\1\s\src\SourceBrowser\src\BinLogParser\BinLogReader.cs:line 63
   at BinLogToSln.Program.Main(String[] args) in D:\a\_work\1\s\src\SourceBrowser\src\BinLogToSln\Program.cs:line 77
```

The reason is that the latest version of MSBuild.StructuredLogger depends on Microsoft.Build.Framework 17.5.0, which only ships with net7.0 and net4.7.2 implementation assemblies, but the BinLogToSln tool is targeting net6.0. We didn't see build issues because we're suppressing the NU1701 warning.

To fix this, move to net8.0 for the projects and use Central Package Management. We bump all MSBuild dependencies to 17.5.0 and also stop targeting netstandard2.0 for Common.csproj and BinLogParser.csproj, this allows us to remove the NU1701 suppression and ensures we're getting correct dependencies.

I'm planning on upstreaming the CPM change to https://github.com/KirillOsenkov/SourceBrowser later.