### PR TITLE
Don't upload 18 gigs of source code per-build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,10 +44,6 @@ extends:
             condition: always()
             targetPath: $(Build.ArtifactStagingDirectory)/logs
             artifactName: logs
-          - output: pipelineArtifact
-            condition: always()
-            targetPath: bin/repo
-            artifactName: repo-logs
 
         steps:
         - checkout: self


### PR DESCRIPTION
It's not entirely clear what the intent was behind this artifact, but it's been uploading every byte of every indexed repo for at least 3 years, for no discernible reason. If this causes a problem down the line, we might be better placed to understand what we _actually_ want uploaded, because I can't fathom a world where this right here is doing a thing we want as-is.