### PR TITLE
New non-SAS version of blob upload

### DIFF
--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -73,9 +73,10 @@
 
   <!-- dependencies for dotnet/source-browser projects -->
   <ItemGroup>
-      <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.0" />
-      <PackageVersion Include="Mono.Options" Version="6.6.0.161" />
-      <PackageVersion Include="SharpZipLib" Version="1.3.3" />
+      <PackageVersion Include="Azure.Identity" Version="1.11.2" />
+      <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
+      <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
+      <PackageVersion Include="SharpZipLib" Version="1.4.2" />
       <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/UploadIndexStage1/UploadIndexStage1.csproj
+++ b/src/UploadIndexStage1/UploadIndexStage1.csproj
@@ -6,10 +6,11 @@
     <PackAsTool>true</PackAsTool>
     <RollForward>Major</RollForward>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Mono.Options" />
     <PackageReference Include="SharpZipLib" />


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet for list of credentials which are used, in order.

I bumped the version number since this is an ABI break (`-o` flag no longer works; new `-s`, `-c` and `-b` flags are needed, so changes to the Arcade template are needed)