### PR TITLE
Run build with dotnet msbuild, not VS msbuild

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,28 +78,28 @@ extends:
               src\SourceBrowser\SourceBrowser.sln
             arguments: '/p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages'
 
-        - task: VSBuild@1
+        - task: DotNetCoreCLI@2
           displayName: Clone All Repositories
           inputs:
-            solution: build.proj
-            msbuildArgs: /t:Clone /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/clone.binlog
-            msbuildArchitecture: x64
+            command: 'build'
+            projects: 'build.proj'
+            arguments: '/t:Clone /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/clone.binlog'
           env:
             source-dot-net-stage1-blob-container-url: $(source-dot-net-stage1-blob-container-url)
 
-        - task: VSBuild@1
+        - task: DotNetCoreCLI@2
           displayName: Prepare All Repositories
           inputs:
-            solution: build.proj
-            msbuildArgs: /t:Prepare /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/prepare.binlog
-            msbuildArchitecture: x64
+            command: 'build'
+            projects: 'build.proj'
+            arguments: '/t:Prepare /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/prepare.binlog'
 
-        - task: VSBuild@1
+        - task: DotNetCoreCLI@2
           displayName: Build source index
           inputs:
-            solution: build.proj
-            msbuildArgs: /t:BuildIndex /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/build.binlog
-            msbuildArchitecture: x64
+            command: 'build'
+            projects: 'build.proj'
+            arguments: '/t:BuildIndex /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/build.binlog'
 
         - task: CopyFiles@2
           inputs:


### PR DESCRIPTION
VS msbuild seems incapable of dealing with the transitive dependencies of the new (CVE-free) versions of the Azure SDK assemblies, and fails the build when attempting to use the downloader task. Switch to using `DotNetCli@2` instead of `VSBuild@1`. The assemblies are still being built for net472, but the newer msbuild is happier resolving the things it needs to.