### PR TITLE
Treat stubs projects same as ref

### DIFF
--- a/src/SourceBrowser/src/BinLogToSln/Program.cs
+++ b/src/SourceBrowser/src/BinLogToSln/Program.cs
@@ -83,7 +83,8 @@ namespace BinLogToSln
                     continue;
                 }
 
-                if (Path.GetFileName(invocation.ProjectDirectory) == "ref")
+                string projectFolder = Path.GetFileName(invocation.ProjectDirectory);
+                if (projectFolder == "ref" || projectFolder == "stubs")
                 {
                     Console.WriteLine($"Skipping Ref Assembly project {invocation.ProjectFilePath}");
                     continue;

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -197,7 +197,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         var invocations = BinLogCompilerInvocationsReader.ExtractInvocations(path);
                         foreach (var invocation in invocations)
                         {
-                            if (Path.GetFileName(invocation.ProjectDirectory) == "ref")
+                            string projectFolder = Path.GetFileName(invocation.ProjectDirectory);
+                            if (projectFolder == "ref" || projectFolder == "stubs")
                             {
                                 Log.Write($"Skipping Ref Assembly project {invocation.ProjectFilePath}");
                                 continue;


### PR DESCRIPTION
Projects in https://github.com/dotnet/runtime/tree/6437b4868b6c41c9dc0708470ff41079b3b46f78/src/libraries/shims/stubs should be treated same as ref.