### PR TITLE
Avoid using sas tokens for uploading index to the final storage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ extends:
           displayName: Normalize Case Of Index Files
 
         - task: AzureCLI@2
-          displayName: Upload Index to Azure Storage
+          displayName: Create new storage container
           inputs:
             azureSubscription: SourceDotNet-Deployment-ARM
             scriptLocation: inlineScript
@@ -139,8 +139,16 @@ extends:
             inlineScript: >
               deployment/upload-index-to-container.ps1
               -StorageAccountName netsourceindex
-              -IndexSource bin/index/index/
               -OutFile bin/index.url
+
+        - task: AzureFileCopy@6
+          displayName: Upload index to Azure Stroage
+          inputs:
+            azureSubscription: SourceDotNet-Deployment-ARM
+            SourcePath: "bin/index/index/*"
+            Destination: AzureBlob
+            storage: netsourceindex
+            ContainerName: $(NEW_CONTAINER_NAME)
 
         - task: AzureRmWebAppDeployment@4
           displayName: 'Azure App Service Deploy: netsourceindex'

--- a/deployment/cleanup-old-containers.ps1
+++ b/deployment/cleanup-old-containers.ps1
@@ -11,13 +11,11 @@ param(
 $ErrorActionPreference = "Stop"
 Import-Module $PSScriptRoot/util.ps1 -Force
 
-$StorageAccountKey = Get-StorageAccountKey -StorageAccountName $StorageAccountName
-
 $allContainers = New-Object System.Collections.Generic.HashSet[string]
 
 Write-Host "Finding containers..."
 {
-  az storage container list --account-name netsourceindex --account-key $StorageAccountKey --auth-mode key --query '[*].name' | ConvertFrom-Json | Write-Output | %{
+  az storage container list --account-name netsourceindex --auth-mode login --query '[*].name' | ConvertFrom-Json | Write-Output | %{
     $allContainers.Add($_)
   } | Out-Null
 } | Check-Failure
@@ -79,7 +77,7 @@ $toDelete | %{
   } else {
     Write-Host "Container $_ has TTL $ttl, deleting..."
     {
-      az storage container delete --name $_ --account-name $StorageAccountName --account-key $StorageAccountKey --auth-mode key
+      az storage container delete --name $_ --account-name $StorageAccountName --auth-mode login
     } | Check-Failure
     Write-Host "Container $_ deleted."
   }

--- a/deployment/upload-index-to-container.ps1
+++ b/deployment/upload-index-to-container.ps1
@@ -1,32 +1,18 @@
 param(
   [string]$StorageAccountName,
-  [string]$IndexSource,
   [string]$OutFile
 )
 
-
 $ErrorActionPreference = "Stop"
 Import-Module $PSScriptRoot/util.ps1
-
-$StorageAccountKey = Get-StorageAccountKey -StorageAccountName $StorageAccountName
 
 $newContainerName = "index-$((New-Guid).ToString("N"))"
 
 Write-Host "Creating new container '$newContainerName'..."
 {
-  az storage container create --name "$newContainerName" --auth-mode key --public-access container --fail-on-exist --account-name $StorageAccountName --account-key "$StorageAccountKey"
+  az storage container create --name "$newContainerName" --auth-mode login --public-access container --fail-on-exist --account-name $StorageAccountName
 } | Check-Failure
 
-Write-Host "Generating sas-token for container..."
-{
-  $script:sas = az storage container generate-sas --name "$newContainerName" --account-name $StorageAccountName --account-key "$StorageAccountKey" --auth-mode key --permissions cadlrw --expiry $((Get-Date).ToUniversalTime().AddDays(1).ToString("yyyy-MM-ddTHH:mm:ssZ")) | convertfrom-json
-} | Check-Failure
-
-Write-Host "Copying index files into container with azcopy..."
-{
-  azcopy.exe sync $IndexSource "https://$StorageAccountName.blob.core.windows.net/$newContainerName/?$sas" --delete-destination true --log-level ERROR
-} | Check-Failure
-
-Write-Output "Uploaded index to 'https://$StorageAccountName.blob.core.windows.net/$newContainerName'"
+Write-Output "##vso[task.setvariable variable=NEW_CONTAINER_NAME]$newContainerName"
 
 "https://$StorageAccountName.blob.core.windows.net/$newContainerName" | Out-File $OutFile

--- a/deployment/util.ps1
+++ b/deployment/util.ps1
@@ -12,29 +12,6 @@ function Check-Failure
     }
 }
 
-$script:AccountKeys = @{}
-
-function Get-StorageAccountKey
-{
-  param(
-    [string]$StorageAccountName
-  )
-
-  if ($script:AccountKeys[$StorageAccountName]) {
-    return $script:AccountKeys[$StorageAccountName]
-  }
-
-  Write-Host "Retrieving keys for storage account '$StorageAccountName'..."
-
-  {
-    $script:AccountKeys[$StorageAccountName] = az storage account keys list --account-name $StorageAccountName | ConvertFrom-Json | Write-Output | select -expandproperty value | select -First 1
-  } | Check-Failure
-
-
-  Write-Output $script:AccountKeys[$StorageAccountName]
-}
-
-
 $script:TTLS = @{}
 
 function Get-ContainerTTL
@@ -43,12 +20,11 @@ function Get-ContainerTTL
     [string]$StorageAccountName,
     [string]$ContainerName
   )
-  $StorageAccountKey = Get-StorageAccountKey -StorageAccountName $StorageAccountName
-  
+
   $script:TTLS[$StorageAccountName] = 10
 
   {
-    $res = az storage container metadata show --name $ContainerName --account-name $StorageAccountName --account-key $StorageAccountKey --auth-mode key --query 'TTL' | ConvertFrom-Json
+    $res = az storage container metadata show --name $ContainerName --account-name $StorageAccountName --auth-mode login --query 'TTL' | ConvertFrom-Json
     Write-Verbose "Got TTL $res from container $ContainerName"
     if ($res -ne $null) {
       $script:TTLS[$StorageAccountName] = $res
@@ -66,10 +42,9 @@ function Set-ContainerTTL
     [string]$ContainerName,
     [int]$TTL
   )
-  $StorageAccountKey = Get-StorageAccountKey -StorageAccountName $StorageAccountName
 
   {
     Write-Verbose "Writing TTL $TTL to container $ContainerName"
-    az storage container metadata update --metadata "TTL=$TTL" --name $ContainerName --account-name $StorageAccountName --account-key $StorageAccountKey --auth-mode key | Out-Null
+    az storage container metadata update --metadata "TTL=$TTL" --name $ContainerName --account-name $StorageAccountName --auth-mode login | Out-Null
   } | Check-Failure
 }


### PR DESCRIPTION
.. container.

Instead, use the already logged in managed identity to upload the index using the `AzureFileCopy@6` azdo task.

I tried to use `azcopy`, `az storage blob sync`, and `az storage azcopy blob sync` but none of them worked as they do not seem to support managed identity.

This commit should be paired with turning off key-based access for the storage.