### PR TITLE
Switch WCF to RepositoryV2

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -46,13 +46,10 @@
         $(ArcadeBuildCmd)
       </PrepareCommand>
     </Repository>
-    <Repository Include="wcf">
+    <RepositoryV2 Include="wcf">
+      <RepoName>dotnet-wcf</RepoName>
       <Url>https://github.com/dotnet/wcf</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-      <Branch>main</Branch>
-    </Repository>
+    </RepositoryV2>
     <RepositoryV2 Include="aspnetcore">
       <RepoName>dotnet-aspnetcore</RepoName>
       <Url>https://github.com/dotnet/aspnetcore</Url>


### PR DESCRIPTION
WCF has already been participating in in-build source index publishing to netsourceindexstage1 - but we haven't been ingesting that data. Stop building it ourselves, and consume the data we've been given.