### PR TITLE
Deploy non-main builds to a validation slot only, not staging->prod

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,7 @@ extends:
             WebAppName: netsourceindex
             ResourceGroupName: source.dot.net
             deployToSlotOrASE: true
-            SlotName: ${{ variables.deploymentSlot }}
+            SlotName: $(deploymentSlot)
             packageForLinux: bin/index-stage/
             enableCustomDeployment: true
             DeploymentType: zipDeploy
@@ -181,7 +181,7 @@ extends:
               -ProxyUrlFile bin/index.url
               -ResourceGroup source.dot.net
               -WebappName netsourceindex
-              -Slot ${{ variables.deploymentSlot }}
+              -Slot $(deploymentSlot)
 
         - task: AzureCLI@2
           displayName: Restart WebApp
@@ -190,13 +190,13 @@ extends:
             scriptLocation: inlineScript
             scriptType: ps
             inlineScript: |
-              az webapp restart --name netsourceindex --slot ${{ variables.deploymentSlot }} --resource-group source.dot.net
+              az webapp restart --name netsourceindex --slot $(deploymentSlot) --resource-group source.dot.net
 
         - pwsh: |
             Start-Sleep 60
             $urls = @(
-              "https://netsourceindex-${{ variables.deploymentSlot }}.azurewebsites.net",
-              "https://netsourceindex-${{ variables.deploymentSlot }}.azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
+              "https://netsourceindex-$(deploymentSlot).azurewebsites.net",
+              "https://netsourceindex-$(deploymentSlot).azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
             )
             foreach ($url in $urls) {
               $statusCode = Invoke-WebRequest $url -UseBasicParsing -SkipHttpErrorCheck | select -ExpandProperty StatusCode

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,11 @@ extends:
         timeoutInMinutes: 360
 
         variables:
+        - name: deploymentSlot
+          value: 'validation'
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+          - name: deploymentSlot
+            value: 'staging'
         - group: source-dot-net stage1 variables
 
         templateContext:
@@ -159,7 +164,7 @@ extends:
             WebAppName: netsourceindex
             ResourceGroupName: source.dot.net
             deployToSlotOrASE: true
-            SlotName: staging
+            SlotName: $(stagingSlot)
             packageForLinux: bin/index-stage/
             enableCustomDeployment: true
             DeploymentType: zipDeploy
@@ -176,7 +181,7 @@ extends:
               -ProxyUrlFile bin/index.url
               -ResourceGroup source.dot.net
               -WebappName netsourceindex
-              -Slot staging
+              -Slot $(stagingSlot)
 
         - task: AzureCLI@2
           displayName: Restart WebApp
@@ -185,13 +190,13 @@ extends:
             scriptLocation: inlineScript
             scriptType: ps
             inlineScript: |
-              az webapp restart --name netsourceindex --slot staging --resource-group source.dot.net
+              az webapp restart --name netsourceindex --slot $(stagingSlot) --resource-group source.dot.net
 
         - pwsh: |
             Start-Sleep 60
             $urls = @(
-              "https://netsourceindex-staging.azurewebsites.net",
-              "https://netsourceindex-staging.azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
+              "https://netsourceindex-$(stagingSlot).azurewebsites.net",
+              "https://netsourceindex-$(stagingSlot).azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
             )
             foreach ($url in $urls) {
               $statusCode = Invoke-WebRequest $url -UseBasicParsing -SkipHttpErrorCheck | select -ExpandProperty StatusCode
@@ -202,27 +207,28 @@ extends:
             }
           displayName: Test Deployed WebApp
 
-        - task: AzureCLI@2
-          displayName: Swap Staging Slot into Production
-          inputs:
-            azureSubscription: SourceDotNet-Deployment-ARM
-            scriptLocation: inlineScript
-            scriptType: ps
-            inlineScript: >
-              az webapp deployment slot swap
-              --resource-group source.dot.net
-              --name netsourceindex
-              --slot staging
-              --target-slot production
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+          - task: AzureCLI@2
+            displayName: Swap Staging Slot into Production
+            inputs:
+              azureSubscription: SourceDotNet-Deployment-ARM
+              scriptLocation: inlineScript
+              scriptType: ps
+              inlineScript: >
+                az webapp deployment slot swap
+                --resource-group source.dot.net
+                --name netsourceindex
+                --slot staging
+                --target-slot production
 
-        - task: AzureCLI@2
-          displayName: Cleanup Old Storage Containers
-          inputs:
-            azureSubscription: SourceDotNet-Deployment-ARM
-            scriptLocation: inlineScript
-            scriptType: ps
-            inlineScript: >
-              deployment/cleanup-old-containers.ps1
-              -ResourceGroup source.dot.net
-              -WebappName netsourceindex
-              -StorageAccountName netsourceindex
+          - task: AzureCLI@2
+            displayName: Cleanup Old Storage Containers
+            inputs:
+              azureSubscription: SourceDotNet-Deployment-ARM
+              scriptLocation: inlineScript
+              scriptType: ps
+              inlineScript: >
+                deployment/cleanup-old-containers.ps1
+                -ResourceGroup source.dot.net
+                -WebappName netsourceindex
+                -StorageAccountName netsourceindex

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,7 @@ extends:
             WebAppName: netsourceindex
             ResourceGroupName: source.dot.net
             deployToSlotOrASE: true
-            SlotName: $(stagingSlot)
+            SlotName: ${{ variables.stagingSlot }}
             packageForLinux: bin/index-stage/
             enableCustomDeployment: true
             DeploymentType: zipDeploy
@@ -181,7 +181,7 @@ extends:
               -ProxyUrlFile bin/index.url
               -ResourceGroup source.dot.net
               -WebappName netsourceindex
-              -Slot $(stagingSlot)
+              -Slot ${{ variables.stagingSlot }}
 
         - task: AzureCLI@2
           displayName: Restart WebApp
@@ -190,13 +190,13 @@ extends:
             scriptLocation: inlineScript
             scriptType: ps
             inlineScript: |
-              az webapp restart --name netsourceindex --slot $(stagingSlot) --resource-group source.dot.net
+              az webapp restart --name netsourceindex --slot ${{ variables.stagingSlot }} --resource-group source.dot.net
 
         - pwsh: |
             Start-Sleep 60
             $urls = @(
-              "https://netsourceindex-$(stagingSlot).azurewebsites.net",
-              "https://netsourceindex-$(stagingSlot).azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
+              "https://netsourceindex-${{ variables.stagingSlot }}.azurewebsites.net",
+              "https://netsourceindex-${{ variables.stagingSlot }}.azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
             )
             foreach ($url in $urls) {
               $statusCode = Invoke-WebRequest $url -UseBasicParsing -SkipHttpErrorCheck | select -ExpandProperty StatusCode

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,11 +30,18 @@ extends:
         timeoutInMinutes: 360
 
         variables:
-        - name: deploymentSlot
-          value: 'validation'
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+          - name: isOfficialBuild
+            value: true
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+          - name: isOfficialBuild
+            value: false
+        - ${{ if eq(variables.isOfficialBuild, true) }}:
           - name: deploymentSlot
-            value: 'staging'
+            value: staging
+        - ${{ if ne(variables.isOfficialBuild, true) }}:
+          - name: deploymentSlot
+            value: validation
         - group: source-dot-net stage1 variables
 
         templateContext:
@@ -207,7 +214,7 @@ extends:
             }
           displayName: Test Deployed WebApp
 
-        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+        - ${{ if eq(variables.isOfficialBuild, true) }}:
           - task: AzureCLI@2
             displayName: Swap Staging Slot into Production
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,7 @@ extends:
             WebAppName: netsourceindex
             ResourceGroupName: source.dot.net
             deployToSlotOrASE: true
-            SlotName: ${{ variables.stagingSlot }}
+            SlotName: ${{ variables.deploymentSlot }}
             packageForLinux: bin/index-stage/
             enableCustomDeployment: true
             DeploymentType: zipDeploy
@@ -181,7 +181,7 @@ extends:
               -ProxyUrlFile bin/index.url
               -ResourceGroup source.dot.net
               -WebappName netsourceindex
-              -Slot ${{ variables.stagingSlot }}
+              -Slot ${{ variables.deploymentSlot }}
 
         - task: AzureCLI@2
           displayName: Restart WebApp
@@ -190,13 +190,13 @@ extends:
             scriptLocation: inlineScript
             scriptType: ps
             inlineScript: |
-              az webapp restart --name netsourceindex --slot ${{ variables.stagingSlot }} --resource-group source.dot.net
+              az webapp restart --name netsourceindex --slot ${{ variables.deploymentSlot }} --resource-group source.dot.net
 
         - pwsh: |
             Start-Sleep 60
             $urls = @(
-              "https://netsourceindex-${{ variables.stagingSlot }}.azurewebsites.net",
-              "https://netsourceindex-${{ variables.stagingSlot }}.azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
+              "https://netsourceindex-${{ variables.deploymentSlot }}.azurewebsites.net",
+              "https://netsourceindex-${{ variables.deploymentSlot }}.azurewebsites.net/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
             )
             foreach ($url in $urls) {
               $statusCode = Invoke-WebRequest $url -UseBasicParsing -SkipHttpErrorCheck | select -ExpandProperty StatusCode


### PR DESCRIPTION
This failed in CI for an unrelated reason, the actual validation slot changes seem good