### PR TITLE
Use Microsoft.NET.StringTools from VS, not build

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="Microsoft.NET.StringTools" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Memory" />


### PR DESCRIPTION
This resolves a version compatibility problem where `Microsoft.Build.*` are loaded from VS, but `Microsoft.NET.StringTools` is loaded from the HtmlGenerator build directory, and because that assembly isn't correctly ABI-versioned, `Microsoft.NET.StringTools.FowlerNollVo1aHash` is missing and the HTML generation fails.

This issue was set up to fail in https://github.com/dotnet/source-indexer/pull/123 where the `ExcludeAssets="runtime"` was dropped from the `Microsoft.NET.StringTools` `PackageReference`, but didn't start actually failing until our CI machines were updated to VS 17.10.4+ (the version whose MSBuild has a hard dependency on the updated `Microsoft.NET.StringTools`, as per https://github.com/dotnet/msbuild/pull/9860)

Sample build failure: https://dev.azure.com/dnceng/internal/_build/results?buildId=2478133&view=logs&j=ab7887b3-04d8-59d0-1c42-6439487f6cb4&t=49aafd2b-8e7f-565e-c75b-097781902724&l=22759

CI build of this PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2479239&view=logs&s=8ae4f91c-4458-5562-6de2-21d31ca24a26&j=ab7887b3-04d8-59d0-1c42-6439487f6cb4

All credit to Eric St John for noticing the irregularities in assembly loading in the source-indexer build log, finding the relevant PRs to source-indexer/msbuild, and explaining the behaviour of `ExcludeAssets="runtime"`