### PR TITLE
Don't round-trip download through service principal login during stage 1 download

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,30 +93,14 @@ extends:
             arguments: '/p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages'
 
         - task: AzureCLI@2
-          displayName: Get stage 1 auth token
+          displayName: Log in to Azure and clone data
           inputs:
             azureSubscription: 'SourceDotNet Stage1 Publish'
             addSpnToEnvironment: true
             scriptType: 'ps'
             scriptLocation: 'inlineScript'
             inlineScript: |
-              echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$env:servicePrincipalId" 
-              echo "##vso[task.setvariable variable=ARM_ID_TOKEN]$env:idToken"
-              echo "##vso[task.setvariable variable=ARM_TENANT_ID]$env:tenantId"
-
-        - script: |
-            echo "Client ID: $(ARM_CLIENT_ID)"
-            echo "ID Token: $(ARM_ID_TOKEN)"
-            echo "Tenant ID: $(ARM_TENANT_ID)"
-            az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
-          displayName: "Login to Azure"
-
-        - task: DotNetCoreCLI@2
-          displayName: Clone All Repositories
-          inputs:
-            command: 'build'
-            projects: 'build.proj'
-            arguments: '/t:Clone /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/clone.binlog /p:Stage1StorageAccount=netsourceindexstage1 /p:Stage1StorageContainer=stage1'
+              dotnet build build.proj /t:Clone /v:n /bl:$(Build.ArtifactStagingDirectory)/logs/clone.binlog /p:Stage1StorageAccount=netsourceindexstage1 /p:Stage1StorageContainer=stage1
 
         - task: DotNetCoreCLI@2
           displayName: Prepare All Repositories


### PR DESCRIPTION
Security changes on the Azure subscription side have blocked us from using the previous idiom for getting a temporary service principal credential. Instead, use the managed identity service connection directly during download of stage 1 artifacts.

CI build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2486246&view=results