### PR TITLE
Switch Winforms to RepositoryV2

### DIFF
--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -14,13 +14,10 @@
       <RepoName>dotnet-runtime</RepoName>
       <Url>https://github.com/dotnet/runtime</Url>
     </RepositoryV2>
-    <Repository Include="winforms">
+    <RepositoryV2 Include="winforms">
+      <RepoName>dotnet-winforms</RepoName>
       <Url>https://github.com/dotnet/winforms</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-      <Branch>main</Branch>
-    </Repository>
+    </RepositoryV2>
     <RepositoryV2 Include="wpf">
       <RepoName>dotnet-wpf</RepoName>
       <Url>https://github.com/dotnet/wpf</Url>


### PR DESCRIPTION
This is tested on https://netsourceindex-validation.azurewebsites.net/ along with some other inclusions.