### PR TITLE
Actually add an Azure event listener

### DIFF
--- a/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Azure;
+using Azure.Core.Diagnostics;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;

--- a/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
@@ -54,6 +54,8 @@ namespace Microsoft.SourceIndexer.Tasks
                 StorageAccount = "https://" + StorageAccount + ".blob.core.windows.net";
             }
 
+            using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger();
+
             DefaultAzureCredential credential;
             DefaultAzureCredentialOptions credentialoptions;
 

--- a/src/UploadIndexStage1/Program.cs
+++ b/src/UploadIndexStage1/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Diagnostics;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -64,6 +65,8 @@ namespace UploadIndexStage1
             {
                 storageAccount = "https://" + storageAccount + ".blob.core.windows.net";
             }
+
+            using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger();
 
             DefaultAzureCredential credential;
             DefaultAzureCredentialOptions credentialoptions;

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -14,10 +14,32 @@
       <RepoName>dotnet-runtime</RepoName>
       <Url>https://github.com/dotnet/runtime</Url>
     </RepositoryV2>
+    <Repository Include="winforms">
+      <Url>https://github.com/dotnet/winforms</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd)
+      </PrepareCommand>
+      <Branch>main</Branch>
+    </Repository>
     <RepositoryV2 Include="wpf">
       <RepoName>dotnet-wpf</RepoName>
       <Url>https://github.com/dotnet/wpf</Url>
     </RepositoryV2>
+    <Repository Include="iot">
+      <Url>https://github.com/dotnet/iot</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd)
+      </PrepareCommand>
+      <Branch>main</Branch>
+    </Repository>
+    <Repository Include="msbuild">
+      <Url>https://github.com/dotnet/msbuild</Url>
+      <Branch>main</Branch>
+      <DeepClone>true</DeepClone>
+      <PrepareCommand>
+        $(ArcadeBuildCmd)
+      </PrepareCommand>
+    </Repository>
     <RepositoryV2 Include="machinelearning">
       <RepoName>dotnet-machinelearning</RepoName>
       <Url>https://github.com/dotnet/machinelearning</Url>
@@ -30,6 +52,18 @@
       <RepoName>dotnet-aspnetcore</RepoName>
       <Url>https://github.com/dotnet/aspnetcore</Url>
     </RepositoryV2>
+    <Repository Include="performance">
+      <Url>https://github.com/dotnet/performance</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
+      </PrepareCommand>
+    </Repository>
+    <Repository Include="sdk">
+      <Url>https://github.com/dotnet/sdk</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
+      </PrepareCommand>
+    </Repository>
     <RepositoryV2 Include="aspire">
       <RepoName>dotnet-aspire</RepoName>
       <Url>https://github.com/dotnet/aspire</Url>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -14,32 +14,10 @@
       <RepoName>dotnet-runtime</RepoName>
       <Url>https://github.com/dotnet/runtime</Url>
     </RepositoryV2>
-    <Repository Include="winforms">
-      <Url>https://github.com/dotnet/winforms</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-      <Branch>main</Branch>
-    </Repository>
     <RepositoryV2 Include="wpf">
       <RepoName>dotnet-wpf</RepoName>
       <Url>https://github.com/dotnet/wpf</Url>
     </RepositoryV2>
-    <Repository Include="iot">
-      <Url>https://github.com/dotnet/iot</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-      <Branch>main</Branch>
-    </Repository>
-    <Repository Include="msbuild">
-      <Url>https://github.com/dotnet/msbuild</Url>
-      <Branch>main</Branch>
-      <DeepClone>true</DeepClone>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-    </Repository>
     <RepositoryV2 Include="machinelearning">
       <RepoName>dotnet-machinelearning</RepoName>
       <Url>https://github.com/dotnet/machinelearning</Url>
@@ -52,18 +30,6 @@
       <RepoName>dotnet-aspnetcore</RepoName>
       <Url>https://github.com/dotnet/aspnetcore</Url>
     </RepositoryV2>
-    <Repository Include="performance">
-      <Url>https://github.com/dotnet/performance</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
-      </PrepareCommand>
-    </Repository>
-    <Repository Include="sdk">
-      <Url>https://github.com/dotnet/sdk</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
-      </PrepareCommand>
-    </Repository>
     <RepositoryV2 Include="aspire">
       <RepoName>dotnet-aspire</RepoName>
       <Url>https://github.com/dotnet/aspire</Url>


### PR DESCRIPTION
Without a configured listener, we get no info on console.

With it, we get a LOT of useful diagnostics, including burning questions like "what did DefaultAzureCredential actually do?"

`[Informational] Azure-Identity: DefaultAzureCredential.GetToken invoked. Scopes: [ https://storage.azure.com//.default ] ParentRequestId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx`