### PR TITLE
Don't execute CloneV1/CloneV2 unless Repository/RepositoryV2 are non-null

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -94,7 +94,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CloneV1" DependsOnTargets="CloneRepository;CheckoutSources;ResolveHashV1"/>
+  <Target Name="CloneV1" DependsOnTargets="CloneRepository;CheckoutSources;ResolveHashV1" Condition="@(Repository->Count()) &gt; 0"/>
 
   <Target Name="DownloadRepositoryV2" Outputs="%(RepositoryV2.Identity)">
     <DownloadStage1Index
@@ -115,7 +115,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ResolveHashV2"/>
+  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ResolveHashV2" Condition="@(RepositoryV2->Count()) &gt; 0"/>
 
   <Target Name="Clone" DependsOnTargets="CloneV1;CloneV2">
   </Target>

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -94,7 +94,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CloneV1" DependsOnTargets="CloneRepository;CheckoutSources;ResolveHashV1" Condition="@(Repository->Count()) &gt; 0"/>
+  <Target Name="CloneV1" DependsOnTargets="CloneRepository;CheckoutSources;ResolveHashV1" Condition="'@(Repository)' != ''"/>
 
   <Target Name="DownloadRepositoryV2" Outputs="%(RepositoryV2.Identity)">
     <DownloadStage1Index
@@ -115,7 +115,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ResolveHashV2" Condition="@(RepositoryV2->Count()) &gt; 0"/>
+  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ResolveHashV2" Condition="'@(RepositoryV2)' != ''"/>
 
   <Target Name="Clone" DependsOnTargets="CloneV1;CloneV2">
   </Target>


### PR DESCRIPTION
This makes it easier to test locally, since cloning V2 repos is fast and cloning V1 repos is very slow - but without this new conditional, removing V1 repos from repositories.props will cause the build to fail (it tries to run git operations on the source-indexer checkout directly, not on repository checkouts)