### PR TITLE
Dial back debug verbosity

### DIFF
--- a/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
@@ -68,28 +68,12 @@ namespace Microsoft.SourceIndexer.Tasks
 
             if (string.IsNullOrEmpty(ClientId))
             {
-                credentialoptions = new DefaultAzureCredentialOptions
-                {
-                    Diagnostics =
-                    {
-                        LoggedHeaderNames = { "x-ms-request-id" },
-                        LoggedQueryParameters = { "api-version" },
-                        IsAccountIdentifierLoggingEnabled = true
-                    }
-                };
+                credentialoptions = new DefaultAzureCredentialOptions;
                 Log.LogMessage($"Trying to use managed identity without default identity");
             }
             else
             {
-                credentialoptions = new DefaultAzureCredentialOptions
-                {
-                    Diagnostics =
-                    {
-                        LoggedHeaderNames = { "x-ms-request-id" },
-                        LoggedQueryParameters = { "api-version" },
-                        IsAccountIdentifierLoggingEnabled = true
-                    },
-                    ManagedIdentityClientId = ClientId };
+                credentialoptions = new DefaultAzureCredentialOptions { ManagedIdentityClientId = ClientId };
                 Log.LogMessage($"Trying to use managed identity with client id: {ClientId}");
             }
 

--- a/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/DownloadStage1Index.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SourceIndexer.Tasks
 
             if (string.IsNullOrEmpty(ClientId))
             {
-                credentialoptions = new DefaultAzureCredentialOptions;
+                credentialoptions = new DefaultAzureCredentialOptions {};
                 Log.LogMessage($"Trying to use managed identity without default identity");
             }
             else

--- a/src/UploadIndexStage1/Program.cs
+++ b/src/UploadIndexStage1/Program.cs
@@ -79,28 +79,12 @@ namespace UploadIndexStage1
 
             if (string.IsNullOrEmpty(clientId))
             {
-                credentialoptions = new DefaultAzureCredentialOptions
-                {
-                    Diagnostics =
-                    {
-                        LoggedHeaderNames = { "x-ms-request-id" },
-                        LoggedQueryParameters = { "api-version" },
-                        IsAccountIdentifierLoggingEnabled = true
-                    }
-                };
+                credentialoptions = new DefaultAzureCredentialOptions;
                 System.Console.WriteLine("Trying to use managed identity without default identity");
             }
             else
             {
-                credentialoptions = new DefaultAzureCredentialOptions
-                {
-                    Diagnostics =
-                    {
-                        LoggedHeaderNames = { "x-ms-request-id" },
-                        LoggedQueryParameters = { "api-version" },
-                        IsAccountIdentifierLoggingEnabled = true
-                    },
-                    ManagedIdentityClientId = clientId };
+                credentialoptions = new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId };
                 System.Console.WriteLine("Trying to use managed identity with client id: " + clientId);
             }
 

--- a/src/UploadIndexStage1/Program.cs
+++ b/src/UploadIndexStage1/Program.cs
@@ -79,7 +79,7 @@ namespace UploadIndexStage1
 
             if (string.IsNullOrEmpty(clientId))
             {
-                credentialoptions = new DefaultAzureCredentialOptions;
+                credentialoptions = new DefaultAzureCredentialOptions {};
                 System.Console.WriteLine("Trying to use managed identity without default identity");
             }
             else


### PR DESCRIPTION
Turns out the problem was firewalling misconfiguration on the Azure side. Let's not leave lots of trace-level output turned on when we don't need it (but keep some of the better try{}catch{} changes)