### PR TITLE
Fix CG alert around Microsoft.IO.Redist

### DIFF
--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -12,6 +12,9 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
 
+    <!-- component governance -->
+     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
+
     <!-- roslyn -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
 
     <!-- component governance -->
-     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
 
     <!-- roslyn -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.2.0" />


### PR DESCRIPTION
Fixing Component Governance alert due to a transitive dependency.