### PR TITLE
Use AzureCliCredential instead of DefaultAzureCredential

### DIFF
--- a/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Identity;
+﻿using Azure.Core;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using System;
@@ -11,7 +12,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
     public class AzureBlobFileSystem : IFileSystem
     {
         private readonly BlobContainerClient container;
-        private DefaultAzureCredential credential;
+        private TokenCredential credential;
         private string clientId;
 
         public AzureBlobFileSystem(string uri)
@@ -20,9 +21,9 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 clientId = Environment.GetEnvironmentVariable("ARM_CLIENT_ID");
 
             if (string.IsNullOrEmpty(clientId))
-                credential = new DefaultAzureCredential();
+                credential = new AzureCliCredential();
             else
-                credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId });
+                credential = new ManagedIdentityCredential(clientId);
 
             container = new BlobContainerClient(new Uri(uri),
                                                 credential);

--- a/src/UploadIndexStage1/Program.cs
+++ b/src/UploadIndexStage1/Program.cs
@@ -68,8 +68,7 @@ namespace UploadIndexStage1
 
             using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger();
 
-            DefaultAzureCredential credential;
-            DefaultAzureCredentialOptions credentialoptions;
+            TokenCredential credential;
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ARM_CLIENT_ID")))
             {
@@ -79,16 +78,14 @@ namespace UploadIndexStage1
 
             if (string.IsNullOrEmpty(clientId))
             {
-                credentialoptions = new DefaultAzureCredentialOptions {};
+                credential = new AzureCliCredential();
                 System.Console.WriteLine("Trying to use managed identity without default identity");
             }
             else
             {
-                credentialoptions = new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId };
-                System.Console.WriteLine("Trying to use managed identity with client id: " + clientId);
+                System.Console.WriteLine("Trying to use ManagedIdentityCredential with ClientID");
+                credential = new ManagedIdentityCredential(clientId);
             }
-
-            credential = new DefaultAzureCredential(credentialoptions);
 
             BlobServiceClient blobServiceClient = new(
                 new Uri(storageAccount),


### PR DESCRIPTION
.. and use ManagedIdentityCredential when clientId is provided.

Prompted by https://github.com/dotnet/dnceng/issues/5450