### PR TITLE
Embed diagnostics in binlog

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -175,6 +175,9 @@
     </PropertyGroup>
     <Exec Command="$(SourceIndexCmd)" LogStandardErrorAsError="false"/>
     <Copy SourceFiles="@(OverwriteFiles)" DestinationFiles="@(OverwriteFiles -> '$(OutDir)index/%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <ItemGroup>
+      <EmbedInBinlog Include="$(OutDir)index/**/diagnostics.txt"/>
+    </ItemGroup>
   </Target>
 
   <Target Name="Build" DependsOnTargets="Clone;Prepare;BuildIndex"/>


### PR DESCRIPTION
SourceBrowser emits compilation diagnostics into `diagnostics.txt` files. Some can be seen directly like https://source.dot.net/Microsoft.CodeAnalysis/diagnostics.txt but others return 500 (they might be too long), e.g., https://source.dot.net/Microsoft.CodeAnalysis.CSharp/diagnostics.txt. By embedding the files into the binlog, we can inspect them from official CI builds at least.

This should simplify diagnosing issues like https://github.com/dotnet/source-indexer/issues/174.
Official build test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2697195&view=results