### PR TITLE
Replace individual repo entries with VMR source index bundles

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -102,10 +102,14 @@
       OutputDirectory="%(RepositoryV2.ExtractPath)"
       StorageAccount="$(Stage1StorageAccount)"
       BlobContainer="$(Stage1StorageContainer)"/>
+    <!-- Save the hash to a per-identity file so later downloads sharing the same
+         ExtractPath don't silently overwrite it. -->
+    <Copy SourceFiles="%(RepositoryV2.ExtractPath)hash"
+          DestinationFiles="%(RepositoryV2.ExtractPath)hash.%(Identity)" />
   </Target>
 
   <Target Name="ResolveHashV2" Outputs="%(RepositoryV2.Identity)">
-    <ReadLinesFromFile File="%(RepositoryV2.ExtractPath)hash">
+    <ReadLinesFromFile File="%(RepositoryV2.ExtractPath)hash.%(Identity)">
       <Output TaskParameter="Lines" PropertyName="CommitHash"/>
     </ReadLinesFromFile>
     <ItemGroup>
@@ -115,7 +119,23 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ResolveHashV2" Condition="'@(RepositoryV2)' != ''"/>
+  <!-- After downloading, verify entries sharing an ExtractPath have identical hashes.
+       Each per-identity hash file was saved during DownloadRepositoryV2. The bare 'hash'
+       file was left by the last download to that path. Any entry whose per-identity hash
+       differs from the bare hash indicates the bundles came from different builds. -->
+  <Target Name="ValidateSharedHashes" DependsOnTargets="DownloadRepositoryV2"
+          Outputs="%(RepositoryV2.Identity)">
+    <ReadLinesFromFile File="%(RepositoryV2.ExtractPath)hash.%(Identity)">
+      <Output TaskParameter="Lines" PropertyName="_ThisHash"/>
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="%(RepositoryV2.ExtractPath)hash">
+      <Output TaskParameter="Lines" PropertyName="_CanonicalHash"/>
+    </ReadLinesFromFile>
+    <Warning Condition="'$(_ThisHash)' != '$(_CanonicalHash)'"
+             Text="Hash mismatch: '%(RepositoryV2.Identity)' has hash '$(_ThisHash)' but another entry sharing ExtractPath '%(RepositoryV2.ExtractPath)' has hash '$(_CanonicalHash)'. These bundles may be from different builds." />
+  </Target>
+
+  <Target Name="CloneV2" DependsOnTargets="DownloadRepositoryV2;ValidateSharedHashes;ResolveHashV2" Condition="'@(RepositoryV2)' != ''"/>
 
   <Target Name="Clone" DependsOnTargets="CloneV1;CloneV2">
   </Target>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -6,41 +6,19 @@
     </ArcadeBuildCmd>
   </PropertyGroup>
   <ItemGroup>
-    <RepositoryV2 Include="arcade">
-      <RepoName>dotnet-arcade</RepoName>
-      <Url>https://github.com/dotnet/arcade</Url>
+    <!-- Repos indexed via the dotnet/dotnet VMR build (source-build + Windows vertical) -->
+    <RepositoryV2 Include="dotnet">
+      <RepoName>dotnet-dotnet</RepoName>
+      <Url>https://github.com/dotnet/dotnet</Url>
     </RepositoryV2>
-    <RepositoryV2 Include="roslyn">
-      <RepoName>dotnet-roslyn</RepoName>
-      <Url>https://github.com/dotnet/roslyn</Url>
+    <RepositoryV2 Include="dotnet-win">
+      <RepoName>dotnet-dotnet-windows</RepoName>
+      <Url>https://github.com/dotnet/dotnet</Url>
+      <ExtractPath>$(RepositoryPath)dotnet/</ExtractPath>
+      <LocalPath>$(RepositoryPath)dotnet/src/</LocalPath>
     </RepositoryV2>
-    <RepositoryV2 Include="runtime">
-      <RepoName>dotnet-runtime</RepoName>
-      <Url>https://github.com/dotnet/runtime</Url>
-    </RepositoryV2>
-    <RepositoryV2 Include="winforms">
-      <RepoName>dotnet-winforms</RepoName>
-      <Url>https://github.com/dotnet/winforms</Url>
-    </RepositoryV2>
-    <RepositoryV2 Include="wpf">
-      <RepoName>dotnet-wpf</RepoName>
-      <Url>https://github.com/dotnet/wpf</Url>
-    </RepositoryV2>
-    <Repository Include="iot">
-      <Url>https://github.com/dotnet/iot</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-      <Branch>main</Branch>
-    </Repository>
-    <Repository Include="msbuild">
-      <Url>https://github.com/dotnet/msbuild</Url>
-      <Branch>main</Branch>
-      <DeepClone>true</DeepClone>
-      <PrepareCommand>
-        $(ArcadeBuildCmd)
-      </PrepareCommand>
-    </Repository>
+
+    <!-- Repos not in the VMR that still upload their own stage 1 data -->
     <RepositoryV2 Include="maui">
       <RepoName>dotnet-maui</RepoName>
       <Url>https://github.com/dotnet/maui</Url>
@@ -53,22 +31,6 @@
       <RepoName>dotnet-wcf</RepoName>
       <Url>https://github.com/dotnet/wcf</Url>
     </RepositoryV2>
-    <RepositoryV2 Include="aspnetcore">
-      <RepoName>dotnet-aspnetcore</RepoName>
-      <Url>https://github.com/dotnet/aspnetcore</Url>
-    </RepositoryV2>
-    <Repository Include="performance">
-      <Url>https://github.com/dotnet/performance</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
-      </PrepareCommand>
-    </Repository>
-    <Repository Include="sdk">
-      <Url>https://github.com/dotnet/sdk</Url>
-      <PrepareCommand>
-        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
-      </PrepareCommand>
-    </Repository>
     <RepositoryV2 Include="aspire">
       <RepoName>dotnet-aspire</RepoName>
       <Url>https://github.com/dotnet/aspire</Url>
@@ -77,5 +39,20 @@
       <RepoName>dotnet-extensions</RepoName>
       <Url>https://github.com/dotnet/extensions</Url>
     </RepositoryV2>
+
+    <!-- Repos that clone and build locally (no stage 1 upload) -->
+    <Repository Include="iot">
+      <Url>https://github.com/dotnet/iot</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd)
+      </PrepareCommand>
+      <Branch>main</Branch>
+    </Repository>
+    <Repository Include="performance">
+      <Url>https://github.com/dotnet/performance</Url>
+      <PrepareCommand>
+        $(ArcadeBuildCmd) -projects src\benchmarks\micro\MicroBenchmarks.sln
+      </PrepareCommand>
+    </Repository>
   </ItemGroup>
 </Project>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -6,16 +6,22 @@
     </ArcadeBuildCmd>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Repos indexed via the dotnet/dotnet VMR build (source-build + Windows vertical) -->
-    <RepositoryV2 Include="dotnet">
-      <RepoName>dotnet-dotnet</RepoName>
-      <Url>https://github.com/dotnet/dotnet</Url>
-    </RepositoryV2>
+    <!-- Repos indexed via the dotnet/dotnet VMR build (source-build + Windows vertical).
+         The VMR uploads two bundles: 'dotnet-dotnet' from a Linux source-build job
+         (most repos) and 'dotnet-dotnet-windows' for Windows-only repos (winforms,
+         wpf, windowsdesktop) from a Windows vertical. Both entries share the same
+         ExtractPath/LocalPath so the index sees one repo. 'dotnet' is declared last
+         so its hash is authoritative for source links (last-declared entry wins in
+         both hash validation and HtmlGenerator). -->
     <RepositoryV2 Include="dotnet-win">
       <RepoName>dotnet-dotnet-windows</RepoName>
       <Url>https://github.com/dotnet/dotnet</Url>
       <ExtractPath>$(RepositoryPath)dotnet/</ExtractPath>
       <LocalPath>$(RepositoryPath)dotnet/src/</LocalPath>
+    </RepositoryV2>
+    <RepositoryV2 Include="dotnet">
+      <RepoName>dotnet-dotnet</RepoName>
+      <Url>https://github.com/dotnet/dotnet</Url>
     </RepositoryV2>
 
     <!-- Repos not in the VMR that still upload their own stage 1 data -->


### PR DESCRIPTION
The dotnet/dotnet VMR build now uploads source index stage 1 data for all repos built as part of the unified build. This replaces individual per-repo entries (arcade, roslyn, runtime, winforms, wpf, msbuild, aspnetcore, sdk) with two VMR bundle entries:

- dotnet-dotnet: covers all repos from the Linux source-build leg
- dotnet-dotnet-windows: covers Windows-only repos (winforms, wpf, windowsdesktop) from the Windows x64 vertical

Both bundles extract to the same directory so their SLN files merge into a single unified source tree for indexing.

Repos not part of the VMR (maui, machinelearning, wcf, aspire, extensions, iot, performance) are kept as-is.