### PR TITLE
Update to .NET 10.0

### DIFF
--- a/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
+++ b/src/SourceBrowser/src/BinLogParser/BinLogParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>BinLogParser</AssemblyName>
     <RootNamespace>Microsoft.SourceBrowser.BinLogParser</RootNamespace>
   </PropertyGroup>

--- a/src/SourceBrowser/src/BinLogToSln.Tests/BinLogToSln.Tests.csproj
+++ b/src/SourceBrowser/src/BinLogToSln.Tests/BinLogToSln.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBrowser/src/BinLogToSln/BinLogToSln.csproj
+++ b/src/SourceBrowser/src/BinLogToSln/BinLogToSln.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <RollForward>Major</RollForward>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/SourceBrowser/src/Common/Common.csproj
+++ b/src/SourceBrowser/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.SourceBrowser.Common</AssemblyName>
-    <TargetFrameworks>net472;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -46,14 +46,14 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.45" />
     <PackageVersion Include="ManagedEsent" Version="2.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
-    <PackageVersion Include="System.Composition" Version="9.0.7" />
+    <PackageVersion Include="System.Composition" Version="10.0.7" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
 
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
 
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.0.2" />
@@ -63,14 +63,14 @@
     <PackageVersion Include="ExceptionAnalysis.Diagnostics" Version="1.0.0.39796" />
     <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.88" />
 
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="9.0.10" />
-    <PackageVersion Include="System.Resources.Extensions" Version="9.0.7" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.7" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.7" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.7" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.7" />
+    <PackageVersion Include="System.Resources.Extensions" Version="10.0.7" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.7" />
   </ItemGroup>
   
   <!-- dependencies for dotnet/source-browser projects -->
@@ -80,7 +80,7 @@
       <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
       <PackageVersion Include="NuGet.Frameworks" Version="6.13.1" />
       <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-      <PackageVersion Include="System.Reflection.Metadata" Version="9.0.7" />
+      <PackageVersion Include="System.Reflection.Metadata" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/UploadIndexStage1/UploadIndexStage1.csproj
+++ b/src/UploadIndexStage1/UploadIndexStage1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <RollForward>Major</RollForward>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
The version of MSBuild we're using requires net10.0 already.  Update our tools to target it.  Update packages as well so that we're on a consistent baseline.

This won't break consumers who use hardcoded versions for the packages.  Following this we can update the job in arcade to use new packages and net10 sdk.