### PR TITLE
Fix BinLogReader for Linux binlogs and HtmlGenerator duplicate serverPath

### DIFF
--- a/src/SourceBrowser/src/BinLogParser/BinLogReader.cs
+++ b/src/SourceBrowser/src/BinLogParser/BinLogReader.cs
@@ -1,13 +1,9 @@
-using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.CodeAnalysis;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.SourceBrowser.BinLogParser
 {
@@ -37,85 +33,9 @@ namespace Microsoft.SourceBrowser.BinLogParser
 
             var lazyResult = m_binlogInvocationMap.GetOrAdd(binLogFilePath, new Lazy<List<CompilerInvocation>>(() =>
             {
-                // for old format logs, use the legacy reader - this is less desireable because it loads everything into memory
-                if (binLogFilePath.EndsWith(".buildlog", StringComparison.OrdinalIgnoreCase))
-                {
-                    return ExtractInvocationsFromBuild(binLogFilePath);
-                }
-
-                // for new format logs, replay the log to avoid loading everything into memory
-                var invocations = new List<CompilerInvocation>();
-                var reader = new Microsoft.Build.Logging.StructuredLogger.BinLogReader();
-                var taskIdToInvocationMap = new Dictionary<(int, int), CompilerInvocation>();
-                var projectEvaluationToPropertiesMap = new Dictionary<int, Dictionary<string, string>>();
-                var projectInstanceToEvaluationMap = new Dictionary<int, int>();
-
-                void TryGetInvocationFromEvent(object sender, BuildEventArgs args)
-                {
-                    Dictionary<string, string> projectProperties = null;
-                    if (projectInstanceToEvaluationMap.TryGetValue(args.BuildEventContext?.ProjectInstanceId ?? -1, out var evaluationId) &&
-                        projectEvaluationToPropertiesMap.TryGetValue(evaluationId, out var properties))
-                    {
-                        projectProperties = properties;
-
-                        if (args is PropertyReassignmentEventArgs propertyReassignment)
-                        {
-                            properties[propertyReassignment.PropertyName] = propertyReassignment.NewValue;
-                        }
-                        else if (args is PropertyInitialValueSetEventArgs propertyInitialValueSet)
-                        {
-                            properties[propertyInitialValueSet.PropertyName] = propertyInitialValueSet.PropertyValue;
-                        }
-                    }
-
-
-                    var invocation = TryGetInvocationFromRecord(args, taskIdToInvocationMap, projectProperties);
-                    if (invocation != null)
-                    {
-                        invocation.SolutionRoot = Path.GetDirectoryName(binLogFilePath);
-                        invocations.Add(invocation);
-                    }
-                }
-
-                reader.StatusEventRaised += (object sender, BuildStatusEventArgs e) =>
-                {
-                    if (e?.BuildEventContext?.EvaluationId >= 0 &&
-                        e is ProjectEvaluationFinishedEventArgs projectEvalArgs)
-                    {
-                        if (projectEvalArgs?.Properties is IDictionary<string, string> propertiesDict)
-                        {
-                            projectEvaluationToPropertiesMap[e.BuildEventContext.EvaluationId] =
-                                new Dictionary<string, string>(propertiesDict, StringComparer.OrdinalIgnoreCase);
-                        }
-                        else
-                        {
-                            var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-                            foreach (KeyValuePair<string, string> property in projectEvalArgs.Properties)
-                            {
-                                properties[property.Key] = property.Value;
-                            }
-
-                            projectEvaluationToPropertiesMap[e.BuildEventContext.EvaluationId] = properties;
-                        }
-                    }
-                };
-
-                reader.ProjectStarted += (object sender, ProjectStartedEventArgs e) =>
-                {
-                    if (e?.BuildEventContext?.EvaluationId >= 0 &&
-                        e?.BuildEventContext?.ProjectInstanceId >= 0)
-                    {
-                        projectInstanceToEvaluationMap[e.BuildEventContext.ProjectInstanceId] = e.BuildEventContext.EvaluationId;
-                    }
-                };
-
-                reader.TargetStarted += TryGetInvocationFromEvent;
-                reader.MessageRaised += TryGetInvocationFromEvent;
-
-                reader.Replay(binLogFilePath);
-
-                return invocations;
+                // Use the tree-based reader for all formats. The event-based BinLogReader.Replay()
+                // doesn't reliably fire events for newer binlog formats (e.g. MSBuild 18.x / .NET 10).
+                return ExtractInvocationsFromBuild(binLogFilePath);
             }));
 
             var result = lazyResult.Value;
@@ -137,55 +57,6 @@ namespace Microsoft.SourceBrowser.BinLogParser
             });
 
             return invocations;
-        }
-
-        private static CompilerInvocation TryGetInvocationFromRecord(BuildEventArgs args, 
-            Dictionary<(int, int), CompilerInvocation> taskIdToInvocationMap,
-            Dictionary<string,string> projectProperties)
-        {
-            int targetId = args.BuildEventContext?.TargetId ?? -1;
-            int projectId = args.BuildEventContext?.ProjectInstanceId ?? -1;
-
-            if (targetId < 0)
-            {
-                return null;
-            }
-
-            if (args is TargetStartedEventArgs targetStarted && targetStarted.TargetName == "CoreCompile")
-            {
-                var invocation = new CompilerInvocation()
-                {
-                    ProjectFilePath = targetStarted.ProjectFile,
-                    ProjectProperties = projectProperties,
-                };
-                taskIdToInvocationMap[(targetId, projectId)] = invocation;
-                return null;
-            }
-
-            var commandLine = GetCommandLineFromEventArgs(args, out var language);
-            if (commandLine == null)
-            {
-                return null;
-            }
-
-            CompilerInvocation compilerInvocation;
-            if (taskIdToInvocationMap.TryGetValue((targetId, projectId), out compilerInvocation))
-            {
-                compilerInvocation.Language = language == CompilerKind.CSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic;
-                compilerInvocation.CommandLineArguments = commandLine;
-                Populate(compilerInvocation);
-                taskIdToInvocationMap.Remove((targetId, projectId));
-            }
-
-            return compilerInvocation;
-        }
-
-        private static void Populate(CompilerInvocation compilerInvocation)
-        {
-            if (compilerInvocation.Language == LanguageNames.CSharp)
-            {
-                compilerInvocation.OutputAssemblyPath = compilerInvocation.Parsed.GetOutputFilePath(compilerInvocation.Parsed.OutputFileName);
-            }
         }
 
         private static CompilerInvocation TryGetInvocationFromTask(Microsoft.Build.Logging.StructuredLogger.Task task, Microsoft.Build.Logging.StructuredLogger.Build build)
@@ -222,7 +93,9 @@ namespace Microsoft.SourceBrowser.BinLogParser
             var stringsToTrim = new[]
             {
                 "csc.exe ",
+                "csc ",
                 "vbc.exe ",
+                "vbc ",
                 "dotnet exec csc.dll ",
                 "dotnet.exe exec csc.dll",
                 "dotnet exec vbc.dll ",
@@ -253,9 +126,13 @@ namespace Microsoft.SourceBrowser.BinLogParser
             }
 
             {
-                // Trim dotnet cli csc of vbc invocation
+                // Trim dotnet cli csc or vbc invocation
 
                 var i1 = commandLine.IndexOf("dotnet.exe", StringComparison.OrdinalIgnoreCase);
+                if (i1 == -1)
+                {
+                    i1 = commandLine.IndexOf("dotnet ", StringComparison.OrdinalIgnoreCase);
+                }
                 var i2 = commandLine.IndexOf(" exec ", StringComparison.OrdinalIgnoreCase);
                 var i3 = commandLine.IndexOf("csc.dll", StringComparison.OrdinalIgnoreCase);
                 if (i3 == -1)
@@ -274,43 +151,31 @@ namespace Microsoft.SourceBrowser.BinLogParser
             }
 
             {
-                // Trim full path csc.exe or vbc.exe invocation
+                // Trim full path csc or vbc invocation (with or without .exe extension)
+                // Handles both Windows (csc.exe) and Linux (bincore/csc) paths
 
-                var i1 = commandLine.IndexOf("csc.exe", StringComparison.OrdinalIgnoreCase);
-                if (i1 == -1)
+                foreach (var pattern in new[] { "csc.exe", "vbc.exe" })
                 {
-                    i1 = commandLine.IndexOf("vbc.exe", StringComparison.OrdinalIgnoreCase);
+                    var i1 = commandLine.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+                    if (i1 != -1)
+                    {
+                        return TrimHere(i1 + pattern.Length);
+                    }
                 }
 
-                if (i1 != -1)
+                // Linux: compiler path ends with /csc or /vbc (no extension)
+                foreach (var pattern in new[] { "/csc ", "/vbc " })
                 {
-                    return TrimHere(i1 + "csc.exe".Length);
+                    var i1 = commandLine.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+                    if (i1 != -1)
+                    {
+                        return commandLine.Substring(i1 + pattern.Length);
+                    }
                 }
-
             }
 
             return commandLine;
         }
 
-        public static string GetCommandLineFromEventArgs(BuildEventArgs args, out CompilerKind language)
-        {
-            var task = args as TaskCommandLineEventArgs;
-            language = default;
-            if (task == null)
-            {
-                return null;
-            }
-
-            var name = task.TaskName;
-            if (name != "Csc" && name != "Vbc")
-            {
-                return null;
-            }
-
-            language = name == "Csc" ? CompilerKind.CSharp : CompilerKind.VisualBasic;
-            var commandLine = task.CommandLine;
-            commandLine = TrimCompilerExeFromCommandLine(commandLine, language);
-            return commandLine;
-        }
     }
 }

--- a/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         continue;
                     }
 
-                    serverPathMappings.Add(Path.GetFullPath(match.Groups["from"].Value), match.Groups["to"].Value);
+                    serverPathMappings[Path.GetFullPath(match.Groups["from"].Value)] = match.Groups["to"].Value;
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

Fix BinLogToSln/HtmlGenerator tool issues discovered while adding VMR source-index support.

### 1. BinLogReader: Use tree-based reader instead of event-based Replay()

`BinLogReader.Replay()` silently aborts when reading binlogs that lack a `CurrentUICulture` message — a known issue ([MSBuildStructuredLog#936](https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/936)). This is common in binlogs produced on Linux. When `Replay()` hits a `PropertyReassignment` record, it tries to format a resource string that was never initialized, throws an `ArgumentNullException`, catches it internally via `OnException`, and stops replaying — with zero diagnostics to the caller.

**Impact for VMR source-build:** BinLogToSln extracted **zero** compiler invocations from Linux source-build binlogs (arcade, runtime, roslyn, etc.), producing empty SLN files. The same binlogs processed with the tree-based `Serialization.Read()` API work perfectly — arcade yields 25 invocations, runtime yields 895.

**Impact for existing per-repo pipelines:** Most repos (runtime, roslyn, aspnetcore) run their source-index job on Windows agents or cross-compile with `-os linux` on Windows, so their binlogs likely include the culture message and are unaffected. However, any repo that runs source-index natively on Linux could be silently producing empty results. Worth auditing.

The fix switches `ExtractInvocations` to always use the tree-based `Serialization.Read()` path (which was already implemented for `.buildlog` files). This approach:
- Works reliably for all binlog formats (no `Strings.Initialize()` workaround needed)
- Is simpler — no event wiring or state tracking dictionaries
- Throws on parse errors instead of silently aborting
- Fully populates `ProjectProperties` via `GetEvaluation(build).GetProperties()` (verified: ~1000 properties per invocation including TargetFramework)

Also adds Linux compiler path trimming — on Linux, the Csc task command line starts with `/path/to/Roslyn/bincore/csc` (no `.exe` extension), which the old trimming logic didn't handle.

A workaround exists (`Strings.Initialize()` before `Replay()`, as used in [component-detection](https://github.com/microsoft/component-detection/blob/main/src/Microsoft.ComponentDetection.Detectors/nuget/BinLogProcessor.cs)), but the tree-based approach is strictly better for our use case.

### 2. HtmlGenerator: Allow duplicate serverPath mappings

When multiple SLN files from the same VMR build map to the same source directory (e.g., `dotnet-dotnet` and `dotnet-dotnet-windows` both mapping to `src/`), HtmlGenerator crashed with `Dictionary.Add` on duplicate keys. Changed to indexer assignment to allow last-write-wins.

## Testing

- Verified against actual Linux source-build binlogs downloaded from VMR build 2973064
- All 10 existing BinLogToSln tests pass
- Arcade: 0 → 25 invocations, Runtime: 0 → 895 invocations
- Windows binlogs (winforms): 29 invocations (unchanged, still works)
- Property extraction verified: all invocations have full properties including TargetFramework