### PR TITLE
Fix display paths for files and test in official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,7 +226,7 @@ extends:
               Start-Sleep 60
               $urls = @(
                 "https://$(stagingHost)"
-                "https://$(stagingHost)/System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
+                "https://$(stagingHost)/System.Private.CoreLib/src/runtime/src/libraries/System.Private.CoreLib/src/System/String.cs.html"
               )
               foreach ($url in $urls) {
                 Write-Host "Testing URL: $url"

--- a/src/SourceBrowser/src/BinLogToSln/Program.cs
+++ b/src/SourceBrowser/src/BinLogToSln/Program.cs
@@ -233,7 +233,7 @@ namespace BinLogToSln
                 Console.WriteLine($"Converting Project: {invocation.ProjectFilePath}");
 
                 string repoRelativeProjectPath = Path.GetRelativePath(repoRoot, invocation.ProjectFilePath);
-                string projectFilePath = Path.Join(output, "src", repoRelativeProjectPath);
+                string projectFilePath = Path.Join(output, repoRelativeProjectPath);
                 string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
                 string projectDirectory = Path.GetDirectoryName(projectFilePath);
                 Directory.CreateDirectory(projectDirectory);
@@ -245,7 +245,7 @@ namespace BinLogToSln
                     LanguageNames.VisualBasic => (VBProjectTypeGuid, false),
                     _ => (CSharpProjectTypeGuid, true),
                 };
-                sln.WriteLine($"Project(\"{typeGuid}\") = \"{projectName}\", \"{Path.Join("src", repoRelativeProjectPath)}\", \"{GetProjectGuid()}\"");
+                sln.WriteLine($"Project(\"{typeGuid}\") = \"{projectName}\", \"{repoRelativeProjectPath}\", \"{GetProjectGuid()}\"");
                 sln.WriteLine("EndProject");
                 project.WriteLine("<Project Sdk=\"Microsoft.NET.Sdk\">");
                 project.WriteLine("  <PropertyGroup>");
@@ -340,7 +340,7 @@ namespace BinLogToSln
                     {
                         string externalPath = Path.Join("_external", idx++.ToString(), Path.GetFileName(filePath));
                         // not in the repo dir, treat as external
-                        projectRelativePath = Path.Join(Path.GetRelativePath(invocation.ProjectDirectory, repoRoot), "..", externalPath);
+                        projectRelativePath = Path.Join(Path.GetRelativePath(invocation.ProjectDirectory, repoRoot), externalPath);
                         outputFile = Path.Join(output, externalPath);
                     }
                     else
@@ -350,7 +350,7 @@ namespace BinLogToSln
                         {
                             link = repoRelativePath;
                         }
-                        outputFile = Path.Join(output, "src", repoRelativePath);
+                        outputFile = Path.Join(output, repoRelativePath);
                     }
                     Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
                     if (!File.Exists(outputFile))
@@ -375,7 +375,7 @@ namespace BinLogToSln
                     }
 
                     string projToRepoPath = Path.GetRelativePath(invocation.ProjectDirectory, repoRoot);
-                    string projToOutputPath = Path.Join(projToRepoPath, "..");
+                    string projToOutputPath = projToRepoPath;
                     string refPath = DedupeReference(output, path);
                     project.WriteLine($"    <{kind} Include=\"{Path.Join(projToOutputPath, refPath)}\"/>");
                 }

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -21,7 +21,7 @@
     </Repository>
 
     <RepositoryV2>
-      <LocalPath>$(RepositoryPath)%(Identity)/src/</LocalPath>
+      <LocalPath>$(RepositoryPath)%(Identity)/</LocalPath>
       <ExtractPath>$(RepositoryPath)%(Identity)/</ExtractPath>
     </RepositoryV2>
   </ItemDefinitionGroup>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -17,7 +17,7 @@
       <RepoName>dotnet-dotnet-windows</RepoName>
       <Url>https://github.com/dotnet/dotnet</Url>
       <ExtractPath>$(RepositoryPath)dotnet/</ExtractPath>
-      <LocalPath>$(RepositoryPath)dotnet/src/</LocalPath>
+      <LocalPath>$(RepositoryPath)dotnet/</LocalPath>
     </RepositoryV2>
     <RepositoryV2 Include="dotnet">
       <RepoName>dotnet-dotnet</RepoName>


### PR DESCRIPTION
BinLogToSln placed all projects and source files under an extra 'src/' directory in its output, causing the website to display paths like 'src\src\libraries\...' instead of showing the actual repo-relative path. For VMR data this also hid the repo name (e.g. 'runtime') from the display.

Remove the extra nesting so the output structure mirrors the repo-relative paths directly. Adjust the relative path calculations for external files and references that assumed the extra directory level. Update the default RepositoryV2 LocalPath to match.

The test path for the official build was also hardcoded to the old runtime path for String.cs.  I've updated to the new path.

Test build (with the check running) https://dev.azure.com/dnceng/internal/_build/results?buildId=2977290&view=results