### PR TITLE
Fix source.dot.net proxied-index serving (500, .js, references, SolutionExplorer)

### DIFF
--- a/src/SourceBrowser/src/SourceIndexServer/Helpers.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Helpers.cs
@@ -17,7 +17,13 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
                 var fs = new AzureBlobFileSystem(IndexProxyUrl);
                 var props = fs.FileProperties(targetPath);
 
-                context.Response.Headers.Append("Content-Md5", Convert.ToBase64String(props.ContentHash));
+                // Blobs are not guaranteed to carry a Content-MD5 (block-uploaded blobs
+                // lack one unless azcopy is run with --put-md5), so only emit it when present.
+                if (props.ContentHash is { Length: > 0 })
+                {
+                    context.Response.Headers.Append("Content-Md5", Convert.ToBase64String(props.ContentHash));
+                }
+
                 context.Response.Headers.Append("Content-Type", props.ContentType);
                 context.Response.Headers.Append("Etag", props.ETag.ToString());
                 context.Response.Headers.Append("Last-Modified", props.LastModified.ToString("R"));
@@ -51,7 +57,13 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
         {
             var path = context.Request.Path.Value;
 
-            if (!path.EndsWith(".html", StringComparison.Ordinal) && !path.EndsWith(".txt", StringComparison.Ordinal))
+            // The index also ships one generated .js per assembly -- A.files.js, the shared file
+            // list the symbol redirect (A.html) loads -- which lives only in blob storage. Everything
+            // else .js (scripts.js and other chrome) is served locally from wwwroot, so scope the
+            // proxy to just that file rather than all .js.
+            if (!path.EndsWith(".html", StringComparison.Ordinal)
+                && !path.EndsWith(".txt", StringComparison.Ordinal)
+                && !path.EndsWith(".files.js", StringComparison.Ordinal))
             {
                 await next().ConfigureAwait(false);
                 return;

--- a/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/AzureBlobFileSystem.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Core;
+using Azure;
+using Azure.Core;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -6,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
@@ -67,6 +69,21 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
             BlobClient blob = container.GetBlobClient(name);
 
             return blob.OpenRead();
+        }
+
+        // Streams a byte range of a blob to the destination, used to serve individual reference fragments
+        // out of the packed references.pack without downloading the whole (potentially hundreds of MB) blob
+        // or buffering the fragment in memory.
+        public async Task CopyBytesToAsync(string name, long offset, int length, Stream destination)
+        {
+            name = name.ToLowerInvariant();
+            BlobClient blob = container.GetBlobClient(name);
+
+            var options = new BlobDownloadOptions { Range = new HttpRange(offset, length) };
+            var response = await blob.DownloadStreamingAsync(options).ConfigureAwait(false);
+            using Stream stream = response.Value.Content;
+
+            await stream.CopyToAsync(destination).ConfigureAwait(false);
         }
 
         public IEnumerable<string> ReadLines(string name)

--- a/src/SourceBrowser/src/SourceIndexServer/Models/IFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/IFileSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
@@ -9,6 +10,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
         IEnumerable<string> ListFiles(string dirName);
         bool FileExists(string name);
         Stream OpenSequentialReadStream(string name);
+        Task CopyBytesToAsync(string name, long offset, int length, Stream destination);
         IEnumerable<string> ReadLines(string name);
     }
 }

--- a/src/SourceBrowser/src/SourceIndexServer/Models/ReferencePack.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/ReferencePack.cs
@@ -1,35 +1,49 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
     // Reads the packed reference output produced by the HtmlGenerator: a single references.pack holding
     // every per-symbol reference fragment back-to-back, plus a references.index describing each fragment's
     // byte range. Fragments are returned verbatim (preamble and all) so they are byte-identical to the
-    // individual .html files the server used to serve. Positioned reads via RandomAccess are thread-safe,
-    // so a single handle serves concurrent requests without locking.
+    // individual .html files the server used to serve. The index is read once into memory; fragments are
+    // then fetched with positioned reads -- from a local file handle when the index is on disk, or ranged
+    // GETs against blob storage when it is served from Azure (source.dot.net). Both are thread-safe, so a
+    // single pack serves concurrent requests without locking.
     public sealed class ReferencePack : IDisposable
     {
-        private readonly SafeHandleRecord[] _records;
+        private readonly Record[] _records;
         private readonly Dictionary<string, int> _index;
-        private readonly Microsoft.Win32.SafeHandles.SafeFileHandle _packHandle;
+        private readonly IPackData _data;
 
-        private readonly struct SafeHandleRecord
+        private readonly struct Record
         {
             public readonly long Offset;
             public readonly int Length;
 
-            public SafeHandleRecord(long offset, int length)
+            public Record(long offset, int length)
             {
                 Offset = offset;
                 Length = length;
             }
         }
 
-        private ReferencePack(Microsoft.Win32.SafeHandles.SafeFileHandle packHandle, Dictionary<string, int> index, SafeHandleRecord[] records)
+        // Backing store for the concatenated fragment bytes, hiding whether they live on local disk or blob.
+        // Fragments are streamed straight to the response rather than buffered, so a heavily-referenced
+        // symbol's (multi-MB) fragment doesn't force a large-object-heap allocation per request.
+        private interface IPackData : IDisposable
         {
-            _packHandle = packHandle;
+            Task WriteToAsync(long offset, int length, Stream destination);
+        }
+
+        private ReferencePack(IPackData data, Dictionary<string, int> index, Record[] records)
+        {
+            _data = data;
             _index = index;
             _records = records;
         }
@@ -46,61 +60,147 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 return false;
             }
 
-            Dictionary<string, int> index;
-            SafeHandleRecord[] records;
-
             using (var stream = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1 << 20, FileOptions.SequentialScan))
-            using (var reader = new BinaryReader(stream))
             {
-                int count = reader.ReadInt32();
-                index = new Dictionary<string, int>(count, StringComparer.Ordinal);
-                records = new SafeHandleRecord[count];
-
-                for (int i = 0; i < count; i++)
-                {
-                    var id = reader.ReadString();
-                    long offset = reader.ReadInt64();
-                    int length = reader.ReadInt32();
-
-                    records[i] = new SafeHandleRecord(offset, length);
-                    index[id] = i;
-                }
+                ReadIndex(stream, out var index, out var records);
+                var handle = File.OpenHandle(packPath, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.RandomAccess);
+                pack = new ReferencePack(new FilePackData(handle), index, records);
             }
 
-            var handle = File.OpenHandle(packPath, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.RandomAccess);
-            pack = new ReferencePack(handle, index, records);
             return true;
         }
 
-        public bool TryGetFragment(string symbolId, out byte[] fragment)
+        // Loads the pack for an assembly whose index is served from blob storage: the small references.index
+        // is read once into memory, and each fragment is then served with a ranged read of references.pack so
+        // the multi-hundred-MB pack is never downloaded in full.
+        public static bool TryLoadFromBlob(IFileSystem fs, string assembly, out ReferencePack pack)
+        {
+            pack = null;
+
+            var packName = $"/{assembly}/{Constants.ReferencesFileName}/{Constants.ReferencePackFileName}";
+            var indexName = $"/{assembly}/{Constants.ReferencesFileName}/{Constants.ReferenceIndexFileName}";
+
+            if (!fs.FileExists(indexName) || !fs.FileExists(packName))
+            {
+                return false;
+            }
+
+            using (var stream = fs.OpenSequentialReadStream(indexName))
+            {
+                ReadIndex(stream, out var index, out var records);
+                pack = new ReferencePack(new BlobPackData(fs, packName), index, records);
+            }
+
+            return true;
+        }
+
+        private static void ReadIndex(Stream stream, out Dictionary<string, int> index, out Record[] records)
+        {
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+            int count = reader.ReadInt32();
+            index = new Dictionary<string, int>(count, StringComparer.Ordinal);
+            records = new Record[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                var id = reader.ReadString();
+                long offset = reader.ReadInt64();
+                int length = reader.ReadInt32();
+
+                records[i] = new Record(offset, length);
+                index[id] = i;
+            }
+        }
+
+        // Looks up a fragment's location in the pack. The bytes are streamed separately via
+        // WriteFragmentAsync so the caller can set Content-Length before writing the body.
+        public bool TryGetFragment(string symbolId, out long offset, out int length)
         {
             if (!_index.TryGetValue(symbolId, out int recordIndex))
             {
-                fragment = null;
+                offset = 0;
+                length = 0;
                 return false;
             }
 
             var record = _records[recordIndex];
-            fragment = new byte[record.Length];
-
-            int read = 0;
-            while (read < record.Length)
-            {
-                int n = System.IO.RandomAccess.Read(_packHandle, fragment.AsSpan(read), record.Offset + read);
-                if (n == 0)
-                {
-                    fragment = null;
-                    return false;
-                }
-                read += n;
-            }
-
+            offset = record.Offset;
+            length = record.Length;
             return true;
+        }
+
+        public Task WriteFragmentAsync(long offset, int length, Stream destination)
+        {
+            return _data.WriteToAsync(offset, length, destination);
         }
 
         public void Dispose()
         {
-            _packHandle.Dispose();
+            _data.Dispose();
+        }
+
+        private sealed class FilePackData : IPackData
+        {
+            private readonly SafeFileHandle _handle;
+
+            public FilePackData(SafeFileHandle handle)
+            {
+                _handle = handle;
+            }
+
+            public async Task WriteToAsync(long offset, int length, Stream destination)
+            {
+                var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(length, 81920));
+                try
+                {
+                    long position = offset;
+                    int remaining = length;
+                    while (remaining > 0)
+                    {
+                        int chunk = Math.Min(remaining, buffer.Length);
+                        int n = await RandomAccess.ReadAsync(_handle, buffer.AsMemory(0, chunk), position).ConfigureAwait(false);
+                        if (n == 0)
+                        {
+                            break;
+                        }
+
+                        await destination.WriteAsync(buffer.AsMemory(0, n)).ConfigureAwait(false);
+                        position += n;
+                        remaining -= n;
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+
+            public void Dispose()
+            {
+                _handle.Dispose();
+            }
+        }
+
+        private sealed class BlobPackData : IPackData
+        {
+            private readonly IFileSystem _fs;
+            private readonly string _packName;
+
+            public BlobPackData(IFileSystem fs, string packName)
+            {
+                _fs = fs;
+                _packName = packName;
+            }
+
+            public Task WriteToAsync(long offset, int length, Stream destination)
+            {
+                return _fs.CopyBytesToAsync(_packName, offset, length, destination);
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/SourceBrowser/src/SourceIndexServer/Models/StaticFileSystem.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/StaticFileSystem.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
@@ -36,6 +39,36 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 FileShare.None,
                 262144,
                 FileOptions.SequentialScan);
+        }
+
+        public async Task CopyBytesToAsync(string name, long offset, int length, Stream destination)
+        {
+            var path = Path.Combine(rootPath, name);
+            using var handle = File.OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.RandomAccess);
+
+            var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(length, 81920));
+            try
+            {
+                long position = offset;
+                int remaining = length;
+                while (remaining > 0)
+                {
+                    int chunk = Math.Min(remaining, buffer.Length);
+                    int n = await RandomAccess.ReadAsync(handle, buffer.AsMemory(0, chunk), position).ConfigureAwait(false);
+                    if (n == 0)
+                    {
+                        break;
+                    }
+
+                    await destination.WriteAsync(buffer.AsMemory(0, n)).ConfigureAwait(false);
+                    position += n;
+                    remaining -= n;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
 
         public IEnumerable<string> ReadLines(string name)

--- a/src/SourceBrowser/src/SourceIndexServer/ReferencePackMiddleware.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/ReferencePackMiddleware.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
         private readonly RequestDelegate _next;
         private readonly string _rootPath;
         private readonly string _rootPathPrefix;
+        private readonly IFileSystem _blobFileSystem;
         private readonly ConcurrentDictionary<string, Lazy<ReferencePack>> _packs = new(StringComparer.OrdinalIgnoreCase);
 
         public ReferencePackMiddleware(RequestDelegate next, string rootPath)
@@ -24,6 +25,14 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
             _next = next;
             _rootPath = rootPath;
             _rootPathPrefix = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+            // On the proxied deployment (source.dot.net) the index -- including the reference packs -- is
+            // uploaded to blob storage rather than shipped with the webapp, so the packs must be read from
+            // there. A local deployment leaves this null and reads from disk.
+            if (!string.IsNullOrEmpty(Helpers.IndexProxyUrl))
+            {
+                _blobFileSystem = new AzureBlobFileSystem(Helpers.IndexProxyUrl);
+            }
         }
 
         public async Task InvokeAsync(HttpContext context)
@@ -32,11 +41,11 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
 
             if (TryMatch(path, out string assembly, out string symbolId) &&
                 TryGetPack(assembly) is ReferencePack pack &&
-                pack.TryGetFragment(symbolId, out byte[] fragment))
+                pack.TryGetFragment(symbolId, out long offset, out int length))
             {
                 context.Response.ContentType = "text/html";
-                context.Response.ContentLength = fragment.Length;
-                await context.Response.Body.WriteAsync(fragment, 0, fragment.Length);
+                context.Response.ContentLength = length;
+                await pack.WriteFragmentAsync(offset, length, context.Response.Body);
                 return;
             }
 
@@ -152,6 +161,11 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
         {
             var lazy = _packs.GetOrAdd(assembly, a => new Lazy<ReferencePack>(() =>
             {
+                if (_blobFileSystem is not null)
+                {
+                    return ReferencePack.TryLoadFromBlob(_blobFileSystem, a, out var blobPack) ? blobPack : null;
+                }
+
                 var referencesFolder = Path.Combine(_rootPath, a, Constants.ReferencesFileName);
                 return ReferencePack.TryLoad(referencesFolder, out var pack) ? pack : null;
             }));

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/SolutionExplorer.html
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/SolutionExplorer.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Solution Explorer</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<!-- Static fallback served only when the index has no generated SolutionExplorer.html (see the
+     Startup pipeline: proxied/local index first, then wwwroot). Deliberately has no tree or
+     onSolutionExplorerLoad() call, since there is nothing to load. -->
+<body class="solutionExplorerBody">
+    <div class="note">Solution Explorer</div>
+    <div class="folderTitle" style="padding: 8px; white-space: normal;">
+        The solution explorer isn't available for this index. Use the search box above to find types, members, and files.
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Several defects that break source.dot.net, all rooted in the same thing: it serves the index from Azure blob storage through the proxy layer (`SOURCE_BROWSER_INDEX_PROXY_URL` set), where sites that serve the index from local disk (e.g. source.terrafx.dev, proxy disabled) never exercise the affected paths. That's why #264 surfaced them only on source.dot.net.

----------

**`SolutionExplorer.html` -> HTTP 500**

`Helpers.ProxyRequestAsync` called `Convert.ToBase64String(props.ContentHash)` unconditionally. Azure does not guarantee a blob has a `Content-MD5`: block-uploaded blobs (the larger files, e.g. the ~2.8 MB `SolutionExplorer.html`) lack one, whereas smaller single-`PutBlob` uploads carry it. `Convert.ToBase64String(null)` threw, was rethrown as `InvalidOperationException`, and produced an empty-body 500. Every smaller proxied file returned 200 (with a `Content-Md5`), so only the large files broke.

Fix: only append `Content-Md5` when `ContentHash` is present.

----------

**Symbol navigation shows "Don't use this page directly, pass #symbolId to get redirected."**

#264 introduced a two-level symbol redirect where each `A.html` loads a generated per-assembly `A.files.js`. The proxy only served `.html`/`.txt`, so on a proxied deployment the `.js` fell through to the static-file provider -- which does not have the index on local disk -- and 404'd, leaving the redirect stub. Confirmed live: `.../a.html` -> 200 (blob), `.../A.files.js` -> 404.

Fix: also proxy that file, using the same `FileExists` fall-through. Scoped to the `.files.js` suffix -- the only `.js` the generator emits into the index -- so chrome scripts (`scripts.js`) keep serving from wwwroot rather than being proxied.

----------

**Reference fragments (`/{assembly}/R/{id}.html`) -> 404**

The per-symbol reference fragments are packed into a single `references.pack` (+ `references.index`) served by `ReferencePackMiddleware`, which read them via raw `File.*` -- local disk only. On the proxied deployment the pack is uploaded to blob rather than shipped with the webapp, so every reference fragment 404'd. Confirmed live: a real source page linking `R/36a0ef01cb5d5107.html` etc., all 404.

Fix: make `ReferencePack` blob-aware, mirroring how `IndexLoader` already falls back to `AzureBlobFileSystem`. The small `references.index` is read into memory once; each fragment is then streamed straight to the response -- a ranged blob GET, or pooled chunked reads locally -- via a new `IFileSystem.CopyBytesToAsync`. Streaming rather than buffering means a heavily-referenced symbol's (multi-MB) fragment doesn't force a large-object-heap allocation per request. The local file-handle path is otherwise unchanged.

----------

**Graceful `SolutionExplorer.html` fallback**

The nav frame redirects to `/SolutionExplorer.html`; the pipeline serves the generated one from the index (blob or local) and only falls through to wwwroot when it's absent. Added a static placeholder there -- matching the generated page's chrome, but with no tree and no `onSolutionExplorerLoad()` -- so an index without one shows a "use search" note in the nav pane instead of a 404.

----------

Verified `SourceIndexServer` builds clean and the fallback is included on `publish`. The blob paths can only be fully exercised against the live proxied deployment (private container), so a post-deploy check is warranted. This is the vendored SourceBrowser copy; the same fixes should also land upstream in tannergooding/SourceBrowser on the next re-vendor.