### PR TITLE
Nav-pane layout, filtering, and lazy Solution Explorer improvements

### DIFF
--- a/src/Microsoft.SourceIndexer.Tasks/GenerateVmrRepoTags.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/GenerateVmrRepoTags.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.SourceIndexer.Tasks
+{
+    // Reads the dotnet/dotnet VMR's src/source-manifest.json and emits one repo tag per mapped
+    // subfolder, so search can be scoped to the originating repo (dotnet/runtime, dotnet/winforms, ...)
+    // instead of the whole VMR. Source links are unaffected -- this only feeds HtmlGenerator's
+    // /repoPath tagging, not /serverPath, so files still link back to dotnet/dotnet.
+    public class GenerateVmrRepoTags : Task
+    {
+        // Full path to the extracted VMR's src/source-manifest.json.
+        [Required]
+        public string ManifestPath { get; set; }
+
+        // Folder the manifest's repository paths are relative to (the extracted VMR's src directory).
+        [Required]
+        public string SrcRoot { get; set; }
+
+        // One item per repository: ItemSpec is the subfolder's full path, RepoDisplayName its owner/repo tag.
+        [Output]
+        public ITaskItem[] RepoTags { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                ExecuteCore();
+                return !Log.HasLoggedErrors;
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex, true);
+                return false;
+            }
+        }
+
+        private void ExecuteCore()
+        {
+            RepoTags = Array.Empty<ITaskItem>();
+
+            if (!File.Exists(ManifestPath))
+            {
+                // Non-VMR builds (or a manifest that moved) simply produce no sub-tags.
+                Log.LogMessage(MessageImportance.Normal, $"Source manifest '{ManifestPath}' not found; no sub-repo tags generated.");
+                return;
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(ManifestPath));
+            if (!doc.RootElement.TryGetProperty("repositories", out var repositories) ||
+                repositories.ValueKind != JsonValueKind.Array)
+            {
+                Log.LogWarning($"Source manifest '{ManifestPath}' has no 'repositories' array; no sub-repo tags generated.");
+                return;
+            }
+
+            var tags = new List<ITaskItem>();
+            foreach (var repo in repositories.EnumerateArray())
+            {
+                var path = repo.TryGetProperty("path", out var p) ? p.GetString() : null;
+                var remoteUri = repo.TryGetProperty("remoteUri", out var r) ? r.GetString() : null;
+                if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(remoteUri))
+                {
+                    continue;
+                }
+
+                var item = new TaskItem(Path.GetFullPath(Path.Combine(SrcRoot, path)));
+                item.SetMetadata("RepoDisplayName", GetDisplayName(remoteUri));
+                tags.Add(item);
+            }
+
+            RepoTags = tags.ToArray();
+            Log.LogMessage(MessageImportance.Normal, $"Generated {tags.Count} sub-repo tag(s) from '{ManifestPath}'.");
+        }
+
+        // Turns a clone URL into an owner/repo tag, matching the RepoDisplayName convention used for
+        // top-level repositories (the URL minus the github.com prefix).
+        private static string GetDisplayName(string remoteUri)
+        {
+            var s = remoteUri.Trim();
+            if (s.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                s = s.Substring(0, s.Length - ".git".Length);
+            }
+
+            const string prefix = "https://github.com/";
+            if (s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return s.Substring(prefix.Length).Trim('/');
+            }
+
+            // Fall back to the URL path for any non-github remote.
+            return new Uri(s).AbsolutePath.Trim('/');
+        }
+    }
+}

--- a/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
+++ b/src/Microsoft.SourceIndexer.Tasks/Microsoft.SourceIndexer.Tasks.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 </Project>

--- a/src/SourceBrowser/TestCode/TestSolution/ThisIsAnIntentionallyEnormousFileNameDesignedToOverflowTheNavigationPaneHorizontallySoTheResizableSplitterAndStickyRepoFilterCanBeExercised.cs
+++ b/src/SourceBrowser/TestCode/TestSolution/ThisIsAnIntentionallyEnormousFileNameDesignedToOverflowTheNavigationPaneHorizontallySoTheResizableSplitterAndStickyRepoFilterCanBeExercised.cs
@@ -1,0 +1,16 @@
+namespace TestSolution
+{
+    /// <summary>
+    /// Deliberately long file name and type name used to exercise the nav-pane layout: a
+    /// long result line must scroll within its own group (and a long tree node within the
+    /// Solution Explorer) without pushing the repo filter dropdown off-screen, and the
+    /// side-by-side panes stay resizable via the splitter. Search for "ThisIsAn" to see it.
+    /// </summary>
+    public static class ThisIsAnIntentionallyEnormousTypeNameDesignedToOverflowTheNavigationPaneHorizontallySoTheResizableSplitterAndStickyRepoFilterCanBeExercised
+    {
+        public static string ThisIsAnIntentionallyEnormousMethodNameThatAlsoContributesToTheHorizontalWidthOfASingleResultLineForTestingPurposes()
+        {
+            return "overflow";
+        }
+    }
+}

--- a/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.SolutionExplorer.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.SolutionExplorer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Net;
+using System.Text;
 using Microsoft.SourceBrowser.Common;
 using Folder = Microsoft.SourceBrowser.HtmlGenerator.Folder<Microsoft.SourceBrowser.HtmlGenerator.ProjectSkeleton>;
 
@@ -88,9 +90,84 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         private void WriteProject(string assemblyName, string repoName, StreamWriter writer)
         {
             var projectExplorerText = GetProjectExplorerText(assemblyName, repoName);
-            if (!string.IsNullOrEmpty(projectExplorerText))
+            if (string.IsNullOrEmpty(projectExplorerText))
             {
-                writer.WriteLine(projectExplorerText);
+                return;
+            }
+
+            // Split the project's title row from its file subtree and write the subtree to a
+            // per-project fragment the client fetches on first expand (see expandCollapseFolder in
+            // scripts.js). The Solution Explorer document then carries only the repo/solution/project
+            // skeleton, so a large index no longer forces the browser to parse -- and build collapsed
+            // DOM for -- every project's whole file tree up front. Projects with no subtree, or any
+            // that don't split cleanly, fall back to being written inline exactly as before.
+            if (TrySplitProjectSubtree(projectExplorerText, out var titleHtml, out var folderOpenTag, out var subtreeInner)
+                && TryWriteProjectSubtreeFragment(assemblyName, subtreeInner, out var fragmentSrc))
+            {
+                writer.Write(titleHtml);
+                writer.Write(folderOpenTag.Insert(folderOpenTag.Length - 1, " data-src=\"" + WebUtility.HtmlEncode(fragmentSrc) + "\""));
+                writer.WriteLine("</div>");
+                return;
+            }
+
+            writer.WriteLine(projectExplorerText);
+        }
+
+        // GetProjectExplorerText returns a project title div immediately followed by its file-tree
+        // folder div: <div class="projectCSInSolution" ...>Name</div><div class="folder" ...>INNER</div>.
+        // Peel those apart so the title (and its data-repo hook) can stay inline while INNER is deferred.
+        private static bool TrySplitProjectSubtree(string html, out string titleHtml, out string folderOpenTag, out string subtreeInner)
+        {
+            titleHtml = folderOpenTag = subtreeInner = null;
+
+            const string closeTag = "</div>";
+            var titleEnd = html.IndexOf(closeTag, StringComparison.Ordinal);
+            if (titleEnd < 0)
+            {
+                return false;
+            }
+
+            titleEnd += closeTag.Length;
+            var folderOpen = html.IndexOf("<div", titleEnd, StringComparison.Ordinal);
+            if (folderOpen < 0)
+            {
+                return false;
+            }
+
+            var folderOpenEnd = html.IndexOf('>', folderOpen);
+            var lastClose = html.LastIndexOf(closeTag, StringComparison.Ordinal);
+            if (folderOpenEnd < 0 || lastClose <= folderOpenEnd)
+            {
+                return false;
+            }
+
+            var inner = html.Substring(folderOpenEnd + 1, lastClose - (folderOpenEnd + 1));
+            if (inner.Trim().Length == 0)
+            {
+                return false;
+            }
+
+            titleHtml = html.Substring(0, titleEnd);
+            folderOpenTag = html.Substring(folderOpen, folderOpenEnd - folderOpen + 1);
+            subtreeInner = inner;
+            return true;
+        }
+
+        private bool TryWriteProjectSubtreeFragment(string assemblyName, string subtreeInner, out string fragmentSrc)
+        {
+            fragmentSrc = assemblyName + "/" + Constants.SolutionExplorerFragment;
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(SolutionDestinationFolder, assemblyName, Constants.SolutionExplorerFragment),
+                    subtreeInner,
+                    Encoding.UTF8);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Exception(ex, "Failed writing Solution Explorer fragment for " + assemblyName);
+                return false;
             }
         }
 

--- a/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.SolutionExplorer.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.SolutionExplorer.cs
@@ -7,7 +7,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public partial class SolutionFinalizer
     {
-        private void WriteSolutionExplorer(Folder root = null)
+        private void WriteSolutionExplorer(bool emitAssemblyList, Folder root = null)
         {
             if (root == null)
             {
@@ -21,7 +21,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 Log.Write("Solution Explorer...");
                 Markup.WriteSolutionExplorerPrefix(writer);
                 WriteFolder(root, writer);
-                Markup.WriteSolutionExplorerSuffix(writer);
+                Markup.WriteSolutionExplorerSuffix(writer, emitAssemblyList);
             }
         }
 

--- a/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             IReadOnlyDictionary<string, IReadOnlyList<string>> configsByAssembly = null)
         {
             SortProcessedAssemblies();
-            WriteSolutionExplorer(solutionExplorerRoot);
+            WriteSolutionExplorer(emitAssemblyList, solutionExplorerRoot);
             CreateReferencesFiles(additionalReferencedSymbolIdsByAssembly, mergedDivergentReferencesByAssembly, configsByAssembly);
             CreateMasterDeclarationsIndex();
             CreateProjectMap();

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -133,7 +133,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     // existed. Finalization happens directly, exactly as today -- this is what makes the
                     // no-config case trivially byte-identical (the code path is literally untouched).
                     FinalizeProjects(options.EmitAssemblyList, federation);
-                    WebsiteFinalizer.Finalize(runOutputRoot, options.EmitAssemblyList, federation, options.ShowBranding);
+                    WebsiteFinalizer.Finalize(runOutputRoot, federation, options.ShowBranding);
                 }
                 else
                 {
@@ -239,7 +239,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     // as the default/no-config path would, straight into the shared "index/".
                     Paths.SolutionDestinationFolder = Path.Combine(outRoot, "obj", configs[0]);
                     FinalizeProjects(emitAssemblyList, federation);
-                    WebsiteFinalizer.Finalize(outRoot, emitAssemblyList, federation, showBranding);
+                    WebsiteFinalizer.Finalize(outRoot, federation, showBranding);
                     return;
                 }
 
@@ -256,7 +256,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     StringComparer.Ordinal);
 
                 ConfigAwareProjectFinalizer.Finalize(configObjRoots, Paths.WebsiteDestinationFolder, emitAssemblyList, federation, axisTagsByConfig);
-                WebsiteFinalizer.Finalize(outRoot, emitAssemblyList, federation, showBranding);
+                WebsiteFinalizer.Finalize(outRoot, federation, showBranding);
             });
         }
 
@@ -595,7 +595,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
     internal static class WebsiteFinalizer
     {
-        public static void Finalize(string destinationFolder, bool emitAssemblyList, Federation federation, bool showBranding)
+        public static void Finalize(string destinationFolder, Federation federation, bool showBranding)
         {
             string sourcePath = Assembly.GetEntryAssembly().Location;
             sourcePath = Path.GetDirectoryName(sourcePath);
@@ -611,7 +611,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             StampOverviewHtmlWithDate(destinationFolder);
 
-            ApplyScriptsJsCustomizations(destinationFolder, emitAssemblyList, federation, showBranding);
+            ApplyScriptsJsCustomizations(destinationFolder, federation, showBranding);
         }
 
         private static void StampOverviewHtmlWithDate(string destinationFolder)
@@ -702,12 +702,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         // The generated site can run either through SourceIndexServer (which serves wwwroot/scripts.js
         // as its baseline, byte-identical to the checked-in template) or as pure static files, where
         // the copy under index/ -- and, at runtime, SourceIndexServer's own RootPath handler, which is
-        // registered ahead of its wwwroot handler -- is what's actually served. All three toggles below
+        // registered ahead of its wwwroot handler -- is what's actually served. Both toggles below
         // used to independently re-read wwwroot/scripts.js and overwrite index/scripts.js, which meant
-        // combining more than one (e.g. /assemblylist with a federation, or either alongside
-        // /showBranding) silently discarded whichever ran first. They're composed into one read-modify
-        // sequence here so any combination of flags ends up in the final file.
-        private static void ApplyScriptsJsCustomizations(string destinationFolder, bool emitAssemblyList, Federation federation, bool showBranding)
+        // combining them (a federation alongside /showBranding) silently discarded whichever ran first.
+        // They're composed into one read-modify sequence here so any combination of flags ends up in
+        // the final file.
+        private static void ApplyScriptsJsCustomizations(string destinationFolder, Federation federation, bool showBranding)
         {
             var source = Path.Combine(destinationFolder, "wwwroot/scripts.js");
             if (!File.Exists(source))
@@ -717,12 +717,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var text = File.ReadAllText(source);
             var changed = false;
-
-            if (emitAssemblyList)
-            {
-                text = text.Replace("/*USE_SOLUTION_EXPLORER*/true/*USE_SOLUTION_EXPLORER*/", "false");
-                changed = true;
-            }
 
             var sb = new StringBuilder();
             foreach (var server in federation.GetServers())

--- a/src/SourceBrowser/src/HtmlGenerator/Utilities/Constants.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Utilities/Constants.cs
@@ -45,6 +45,9 @@
         public static readonly string ClassificationPunctuation = "punctuation";
         public static readonly string ProjectExplorer = "ProjectExplorer";
         public static readonly string SolutionExplorer = "SolutionExplorer";
+        // Per-project file subtree the merged Solution Explorer defers and the client fetches on
+        // first expand (see SolutionFinalizer.WriteProject), written alongside ProjectExplorer.html.
+        public static readonly string SolutionExplorerFragment = "SolutionExplorerFragment.html";
         public static readonly string HuffmanFileName = "Huffman.txt";
         public static readonly string TopReferencedAssemblies = "TopReferencedAssemblies";
         public static readonly string BaseMembersFileName = "BaseMembers";

--- a/src/SourceBrowser/src/HtmlGenerator/Utilities/Markup.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Utilities/Markup.cs
@@ -291,9 +291,15 @@ Don't use this page directly, pass #symbolId to get redirected.
 <div id=""rootFolder"" style=""display: none;"" class=""folderTitle"">");
         }
 
-        public static void WriteSolutionExplorerSuffix(TextWriter writer)
+        public static void WriteSolutionExplorerSuffix(TextWriter writer, bool emitAssemblyList)
         {
-            writer.WriteLine("</div><script>onSolutionExplorerLoad();</script></body></html>");
+            // Reciprocal of the "solution explorer" link on the assembly list (results.html); only
+            // emitted when that list was generated, so it never points at an empty results page.
+            var assemblyListLink = emitAssemblyList
+                ? @"<div class=""note"">Try also browsing the <a href=""results.html"" class=""blueLink"">assembly list</a>.</div>"
+                : null;
+
+            writer.WriteLine("</div>" + assemblyListLink + "<script>onSolutionExplorerLoad();</script></body></html>");
         }
 
         public static void WriteNamespaceExplorerPrefix(string assemblyName, StreamWriter sw, string pathPrefix = "")
@@ -357,7 +363,7 @@ Don't use this page directly, pass #symbolId to get redirected.
 <select id=""repo-filter"" style=""display:none"" aria-label=""Filter search to a repo""></select>
 <div id=""symbols"" aria-live=""polite"">
 <div class=""note"">
-Enter a type or member name or <a href=""/#q=assembly%20"" target=""_top"" class=""blueLink"" onclick=""populateSearchBox('assembly '); return false;"">filter the assembly list</a>.
+Enter a type or member name.
 </div>
 <div class=""resultGroup"">
 ";

--- a/src/SourceBrowser/src/HtmlGenerator/Utilities/Markup.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Utilities/Markup.cs
@@ -359,7 +359,7 @@ Don't use this page directly, pass #symbolId to get redirected.
 <link rel=""stylesheet"" href=""styles.css"" />
 <script src=""scripts.js""></script>
 </head>
-<body onload=""onResultsLoad();"">
+<body class=""resultsBody"" onload=""onResultsLoad();"">
 <select id=""repo-filter"" style=""display:none"" aria-label=""Filter search to a repo""></select>
 <div id=""symbols"" aria-live=""polite"">
 <div class=""note"">

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/index.html
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/index.html
@@ -21,6 +21,11 @@
                 class="navFrame"
                 src="results.html"
                 title="search-results"></iframe>
+        <div class="paneResizer"
+             id="paneResizer"
+             role="separator"
+             aria-orientation="vertical"
+             title="Drag to resize"></div>
         <iframe name="s"
                 id="s"
                 class="contentFrame"

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
@@ -182,6 +182,8 @@ function onPageLoaded() {
 
     top.name = "topFrame";
 
+    initPaneResizer();
+
     var query = document.location.search;
     if (query && query.slice(0, 3) == "?q=") {
         redirectLocation(top, "/#" + query.slice(1));
@@ -201,6 +203,82 @@ function onPageLoaded() {
     }
 
     processHash();
+}
+
+// Makes the divider between the side-by-side nav and content panes draggable (desktop layout
+// only). The nav pane width is persisted on `top` and in localStorage so it survives frame
+// reloads and return visits. The mobile single-pane layout has no splitter (it's display:none)
+// and must not inherit a fixed pixel width, so the width is cleared whenever that layout is
+// active and reapplied on return to the side-by-side layout.
+function initPaneResizer() {
+    var resizer = document.getElementById("paneResizer");
+    var navFrame = document.getElementById("n");
+    var container = document.getElementById("splitter");
+    if (!resizer || !navFrame || !container) {
+        return;
+    }
+
+    var MIN_WIDTH = 200;
+    var mobile = window.matchMedia(
+        "(max-width: 700px), (orientation: landscape) and (max-height: 500px) and (pointer: coarse)");
+
+    function storedWidth() {
+        var value = parseInt(localStorage.getItem("navPaneWidth"), 10);
+        return isNaN(value) ? 0 : value;
+    }
+
+    function clamp(width) {
+        var max = container.clientWidth - MIN_WIDTH;
+        if (max < MIN_WIDTH) {
+            max = MIN_WIDTH;
+        }
+        return Math.min(Math.max(width, MIN_WIDTH), max);
+    }
+
+    // In the mobile layout the panes stack full-width; a leftover pixel width would override
+    // that, so drop it there and restore the saved width when back to side-by-side.
+    function applyLayout() {
+        if (mobile.matches) {
+            navFrame.style.width = "";
+        } else if (storedWidth()) {
+            navFrame.style.width = clamp(storedWidth()) + "px";
+        }
+    }
+
+    resizer.addEventListener("pointerdown", function (e) {
+        if (mobile.matches) {
+            return;
+        }
+
+        e.preventDefault();
+        document.body.classList.add("resizingPanes");
+
+        // Track the move/up on the document rather than the 6px resizer: once the drag starts the
+        // cursor leaves the handle, and the .resizingPanes rule disables the iframes' pointer
+        // events so these still reach us here.
+        function onMove(ev) {
+            var width = clamp(ev.clientX - container.getBoundingClientRect().left);
+            navFrame.style.width = width + "px";
+        }
+
+        function onUp() {
+            document.body.classList.remove("resizingPanes");
+            document.removeEventListener("pointermove", onMove);
+            document.removeEventListener("pointerup", onUp);
+            localStorage.setItem("navPaneWidth", parseInt(navFrame.style.width, 10));
+        }
+
+        document.addEventListener("pointermove", onMove);
+        document.addEventListener("pointerup", onUp);
+    });
+
+    if (mobile.addEventListener) {
+        mobile.addEventListener("change", applyLayout);
+    } else if (mobile.addListener) {
+        mobile.addListener(applyLayout);
+    }
+
+    applyLayout();
 }
 
 function onHeaderLoad() {

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
@@ -329,6 +329,9 @@ function onResultsLoad() {
     ensureSearchBox();
     initRepoFilter(function () { runSearch(); });
 
+    // The pinned-note height (sticky-header offset) depends on the pane width via wrapping.
+    window.addEventListener("resize", function () { updateGroupHeaderOffset(); });
+
     if (searchBox && searchBox.value && searchBox.value.length > 2) {
         runSearch();
     }
@@ -881,6 +884,20 @@ function embedRepoFilterInNote(scope) {
 
     note.classList.add("hasFilter");
     note.appendChild(repoFilterElement);
+
+    updateGroupHeaderOffset(note);
+}
+
+// The top "N results found" note is pinned (position: sticky, top: 0). Sticky group headers must
+// sit just below it, so publish the note's rendered height as --groupHeaderTop for the CSS to use.
+// The height varies with the embedded filter dropdown and with wrapping, so recompute on resize.
+function updateGroupHeaderOffset(note) {
+    if (!note) {
+        note = document.querySelector("#symbols > .note");
+    }
+
+    var height = note ? note.getBoundingClientRect().height : 0;
+    document.documentElement.style.setProperty("--groupHeaderTop", Math.round(height) + "px");
 }
 
 // Hides/shows each project's subtree in the merged Solution Explorer (SolutionExplorer.html)
@@ -996,6 +1013,12 @@ function loadSearchResults(data) {
             // context, now that the note it was sitting in just got replaced wholesale above.
             if (typeof top.n.embedRepoFilterInNote === "function") {
                 top.n.embedRepoFilterInNote(container);
+            }
+
+            // Groups just got replaced, so re-measure the pinned note for the sticky-header offset
+            // (embedRepoFilterInNote only does this when a filter dropdown is present).
+            if (typeof top.n.updateGroupHeaderOffset === "function") {
+                top.n.updateGroupHeaderOffset();
             }
 
             if (searchBox && searchBox.value && searchBox.value.length > 2) {

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
@@ -1679,6 +1679,36 @@ function expandCollapseFolder(capturedFolder, capturedPlusMinus, capturedFolderI
                 capturedFolderImage.src = pathToIcons + openFolderIcon;
             }
 
+            // A project whose file subtree was deferred (see SolutionFinalizer.WriteProject) carries a
+            // data-src instead of inline children. Fetch and inject it on first expand, then wire the
+            // injected subtree the same way makeFoldersCollapsible does the initial document.
+            var deferredSrc = capturedFolder.getAttribute ? capturedFolder.getAttribute("data-src") : null;
+            if (deferredSrc && !capturedFolder.everExpanded) {
+                capturedFolder.everExpanded = true;
+                var initFn = capturedFolder.initialize;
+                capturedFolder.initialize = null;
+                fetch(deferredSrc)
+                    .then(function (r) { return r.ok ? r.text() : ""; })
+                    .then(function (html) {
+                        capturedFolder.innerHTML = html;
+                        var nested = capturedFolder.querySelectorAll(".folder");
+                        for (var j = 0; j < nested.length; j++) {
+                            nested[j].style.display = "none";
+                            nested[j].initialize = initFn;
+                        }
+                        if (initFn) {
+                            initFn(capturedFolder);
+                        }
+                        for (var k = 0; k < capturedFolder.children.length; k++) {
+                            if (capturedFolder.children[k].className === 'folder') {
+                                addImagesToFolder(capturedFolder.children[k], folderIcon, openFolderIcon, pathToIcons);
+                            }
+                        }
+                    });
+                capturedFolder.style.display = 'block';
+                return;
+            }
+
             if (capturedFolder.initialize) {
                 capturedFolder.initialize(capturedFolder);
                 capturedFolder.initialize = null;

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
@@ -73,9 +73,9 @@ body {
 .navFrame {
     flex: none;
     width: 504px;
+    min-width: 200px;
     height: 100%;
     border: 0;
-    border-right: 1px solid var(--color-pane-border);
 }
 
 .contentFrame {
@@ -83,6 +83,29 @@ body {
     min-width: 0;
     height: 100%;
     border: 0;
+}
+
+/* Draggable divider between the side-by-side panes (desktop only -- hidden in
+   the single-pane mobile layout below). Doubles as the visual border the
+   navFrame used to own. initPaneResizer() in scripts.js sets navFrame's width
+   from a drag here. */
+.paneResizer {
+    flex: none;
+    width: 6px;
+    height: 100%;
+    background: var(--color-pane-border);
+    cursor: col-resize;
+}
+
+.paneResizer:hover,
+body.resizingPanes .paneResizer {
+    background: var(--color-selection);
+}
+
+/* While dragging, the cursor passes over the iframes; disabling their pointer
+   events keeps mousemove flowing to the top document driving the resize. */
+body.resizingPanes iframe {
+    pointer-events: none;
 }
 
 /* On narrow screens show one pane at a time instead of a 504px nav pane
@@ -111,6 +134,11 @@ body {
     }
 
     .navFrame {
+        display: none;
+    }
+
+    /* The splitter only makes sense in the side-by-side layout. */
+    .paneResizer {
         display: none;
     }
 
@@ -859,6 +887,59 @@ a i {
     background-size: 10px 6px;
 }
 
+/* Keep the note strips -- the repo filter dropdown, "N results found:", "Generated in X ms",
+   and the "Try also browsing" footer link -- pinned and visible, and scroll only the result
+   list/tree between them. Without this a single long result line widens the page and pushes the
+   dropdown off-screen, forcing a horizontal scroll just to reach the filter. Applies to the two
+   nav-frame pages that carry the filter: results.html and SolutionExplorer.html. */
+body.resultsBody,
+body.solutionExplorerBody {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+/* results.html: #symbols holds the (sticky) note strips and the scrolling result groups. The
+   footer "solution explorer" link is a sibling below it and stays put on its own. */
+body.resultsBody #symbols {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+body.resultsBody #symbols > .note:first-child {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+body.resultsBody #symbols > .note:last-child {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+}
+
+body.resultsBody > .note {
+    flex: none;
+}
+
+/* A long result line scrolls within its own group rather than widening the whole pane. */
+body.resultsBody .resultGroup {
+    overflow-x: auto;
+}
+
+/* SolutionExplorer.html: the header note and footer link stay put; the tree scrolls between. */
+body.solutionExplorerBody > .note {
+    flex: none;
+}
+
+body.solutionExplorerBody #rootFolder {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+}
 /* Hides a Solution Explorer project subtree that doesn't match the selected repo filter (see
    filterSolutionExplorerByRepo in scripts.js). A class rather than inline display is used so this
    doesn't fight with the folder expand/collapse logic, which also toggles display on the same

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
@@ -959,6 +959,27 @@ body.solutionExplorerBody #rootFolder {
     min-height: 0;
     overflow: auto;
 }
+
+/* Repo (and, on multi-solution sites, solution) grouping headers stay visible while the tree is
+   scrolled. Sticky top floats the header down as its subtree scrolls past so the current repo stays
+   labeled; sticky left plus a full-pane min-width keeps the tint spanning the view even after a long
+   path has scrolled the tree sideways -- otherwise the band would end at the pane's original right
+   edge. The opaque background (repoTitle already tints; solutionTitle gets one) stops scrolled rows
+   from showing through the pinned header. */
+body.solutionExplorerBody .repoTitle,
+body.solutionExplorerBody .solutionTitle {
+    position: sticky;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    min-width: 100%;
+    width: max-content;
+    box-sizing: border-box;
+}
+
+body.solutionExplorerBody .solutionTitle {
+    background-color: #ffffff;
+}
 /* Hides a Solution Explorer project subtree that doesn't match the selected repo filter (see
    filterSolutionExplorerByRepo in scripts.js). A class rather than inline display is used so this
    doesn't fight with the folder expand/collapse logic, which also toggles display on the same

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/styles.css
@@ -925,9 +925,28 @@ body.resultsBody > .note {
     flex: none;
 }
 
-/* A long result line scrolls within its own group rather than widening the whole pane. */
+/* Each result group spans the full pane width (no side margins) so its header tint reads as a
+   full-width band, and the group's own vertical rhythm is preserved by the bottom margin only. */
 body.resultsBody .resultGroup {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* A long result line scrolls within the group's collapsible body -- not the whole group -- so the
+   header above it (which is a sibling of this scroller) stays full-width and can stick on scroll
+   instead of sliding sideways with the content. The small indent keeps items inset under the icon. */
+body.resultsBody .resultGroup > div {
     overflow-x: auto;
+    padding-left: 8px;
+}
+
+/* Project/assembly group headers float at the top of the scroll area while their items scroll past,
+   so the group a result belongs to stays labeled. They stick just below the pinned "N results"
+   note; --groupHeaderTop is that note's measured height (set in embedRepoFilterInNote). */
+body.resultsBody .resultGroupHeader {
+    position: sticky;
+    top: var(--groupHeaderTop, 0px);
+    z-index: 1;
 }
 
 /* SolutionExplorer.html: the header note and footer link stay put; the tree scrolls between. */

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <UsingTask TaskName="DownloadStage1Index" AssemblyFile="$(SourceIndexerTasksAssembly)"/>
+  <UsingTask TaskName="GenerateVmrRepoTags" AssemblyFile="$(SourceIndexerTasksAssembly)"/>
 
   <PropertyGroup>
     <WhatIf Condition="'$(WhatIf)' != 'true'">false</WhatIf>
@@ -177,13 +178,26 @@
     </ItemGroup>
   </Target>
 
+  <!-- For VMR entries carrying a source manifest, emit one repo filter tag per subfolder so
+       search can be scoped to the originating repo. Only /repoPath (filter) tags are added;
+       source links keep pointing at the top-level repo. -->
+  <Target Name="GenerateSubRepoTags" DependsOnTargets="ResolveHashV2"
+          Outputs="%(ClonedRepositoryV2.Identity)">
+    <GenerateVmrRepoTags
+        Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+        ManifestPath="$([MSBuild]::NormalizePath('%(ClonedRepositoryV2.ExtractPath)', '%(ClonedRepositoryV2.SubRepoManifest)'))"
+        SrcRoot="$([MSBuild]::NormalizePath('%(ClonedRepositoryV2.ExtractPath)', 'src'))">
+      <Output TaskParameter="RepoTags" ItemName="SubRepoTag"/>
+    </GenerateVmrRepoTags>
+  </Target>
+
   <Target Name="BuildGenerator" Condition="!Exists('$(HtmlGeneratorExePath)')">
     <MSBuild Projects="$(SourcesDir)SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj" Targets="Restore;Build" Properties="SolutionDir=$(SourcesDir)SourceBrowser">
       <Output TaskParameter="TargetOutputs" PropertyName="HtmlGeneratorExePath"/>
     </MSBuild>
   </Target>
 
-  <Target Name="BuildIndex" DependsOnTargets="BuildGenerator;FindBinlogs;FindSolutions">
+  <Target Name="BuildIndex" DependsOnTargets="BuildGenerator;FindBinlogs;FindSolutions;GenerateSubRepoTags">
     <Error Condition="!Exists('$(HtmlGeneratorExePath)')" Text="Html generator executable not found."/>
     <RemoveDuplicates Inputs="@(BinlogToIndex)">
       <Output TaskParameter="Filtered" ItemName="_FilteredBinlog"/>
@@ -204,6 +218,7 @@
       <SourceIndexCmd>$(SourceIndexCmd) /in:"$(OutDir)index.list"</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepository -> ' /repo:"%(LocalPath)"="%(RepoDisplayName)"="%(ServerPath)"', '')</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepositoryV2 -> ' /repo:"%(LocalPath)"="%(RepoDisplayName)"="%(ServerPath)"', '')</SourceIndexCmd>
+      <SourceIndexCmd>$(SourceIndexCmd)@(SubRepoTag -> ' /repoPath:"%(Identity)"="%(RepoDisplayName)"', '')</SourceIndexCmd>
     </PropertyGroup>
     <Exec Command="$(SourceIndexCmd)" LogStandardErrorAsError="false"/>
     <Copy SourceFiles="@(OverwriteFiles)" DestinationFiles="@(OverwriteFiles -> '$(OutDir)index/%(RecursiveDir)%(Filename)%(Extension)')"/>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -22,6 +22,10 @@
     <RepositoryV2 Include="dotnet">
       <RepoName>dotnet-dotnet</RepoName>
       <Url>https://github.com/dotnet/dotnet</Url>
+      <!-- Emit a per-subfolder repo filter tag for each entry in the VMR's source manifest,
+           so search can be scoped to the originating repo (dotnet/runtime, ...). Source links
+           are unaffected: files still point at dotnet/dotnet. -->
+      <SubRepoManifest>src/source-manifest.json</SubRepoManifest>
     </RepositoryV2>
 
     <!-- Repos not in the VMR that still upload their own stage 1 data -->


### PR DESCRIPTION
﻿A batch of SourceBrowser nav-pane improvements, driven by source.dot.net's scale (26 repos / 1208 projects) but applicable to any large index (e.g. source.terrafx.dev).

## Per-subfolder repo filter tags for the dotnet/dotnet VMR
Tags each project with its originating repo (`data-repo`) so the nav pane can filter by sub-folder within the VMR while keeping the `dotnet/dotnet` URL. Adds a build task (`GenerateVmrRepoTags`) that derives the tags.

----------

## Solution Explorer as the default view
Defaults the nav pane to the Solution Explorer and pairs it with the assembly list, rather than opening on the assembly list. Removes the redundant "filter the assembly list" link from the assembly-list page (it belongs to the overview) to match the Solution Explorer treatment.

----------

## Resizable panes + pinned filter/notes
Makes the side-by-side panels resizable when not in mobile/stacked layout, and keeps the repo-select dropdown within the window bounds instead of pushing off-screen on very long entries. The "displaying N results", "generated in N ms", and "try also browsing" notes stay pinned/visible while only the results list scrolls.

----------

## Full-width, floating group headers
Search-result project groups and Solution Explorer repo/solution groups now extend the full pane width (left and right), and their grouping headers float (`position: sticky`) so the project/repo/solution context stays visible while scrolling. Horizontal overflow is contained to the group body so headers stay put.

----------

## Lazy Solution Explorer (main perf win)
The merged Solution Explorer inlined every project's full file and reference subtree into the document, forcing the browser to parse and build collapsed DOM for the entire index up front -- a multi-second load on a large index like source.dot.net.

Each project's subtree is now written to a per-project `SolutionExplorerFragment.html`, and the document carries only a `data-src` placeholder. The client fetches and wires the subtree on first expand (guarded against re-fetch on collapse/re-expand), mirroring how the namespace explorer already defers. Projects with no subtree, or any that don't split cleanly, fall back to inline; fragment-write failures fall back to inline.

On the test site this drops `SolutionExplorer.html` from the full inlined tree to a ~2KB skeleton. `data-repo` hooks remain on the skeleton rows, so the repo filter is unaffected, and reference/file links rewrite correctly on expand.

**Deferred / follow-up:** repo-level deferral (initial doc = repo headers only) is a reasonable next increment if the ~2400-node per-project skeleton still exceeds budget on the real source.dot.net index -- but it requires reworking the repo-filter dropdown to become the lazy-expand trigger, so it's intentionally left out of this PR. Still-open item: the references view lacks a repo filter on the "no references found" entry.

## Validation
- 178/178 HtmlGenerator tests pass.
- Lazy expand verified live (Playwright): first expand fetches the fragment once, collapse/re-expand doesn't re-fetch, `@0@#` reference placeholders rewrite on subfolder expand, repo filter intact.
