### PR TITLE
Fix source.dot.net branding and fetch the VMR manifest via git

### DIFF
--- a/src/Microsoft.SourceIndexer.Tasks/GenerateVmrRepoTags.cs
+++ b/src/Microsoft.SourceIndexer.Tasks/GenerateVmrRepoTags.cs
@@ -13,7 +13,8 @@ namespace Microsoft.SourceIndexer.Tasks
     // /repoPath tagging, not /serverPath, so files still link back to dotnet/dotnet.
     public class GenerateVmrRepoTags : Task
     {
-        // Full path to the extracted VMR's src/source-manifest.json.
+        // Path to the VMR's source-manifest.json, fetched at the pinned commit by the build (the
+        // extracted bundle can be a partial vertical whose manifest is missing or incomplete).
         [Required]
         public string ManifestPath { get; set; }
 
@@ -45,8 +46,9 @@ namespace Microsoft.SourceIndexer.Tasks
 
             if (!File.Exists(ManifestPath))
             {
-                // Non-VMR builds (or a manifest that moved) simply produce no sub-tags.
-                Log.LogMessage(MessageImportance.Normal, $"Source manifest '{ManifestPath}' not found; no sub-repo tags generated.");
+                // A VMR entry that opted into sub-tagging but has no manifest is a misconfiguration
+                // worth surfacing, not a silent no-op.
+                Log.LogWarning($"Source manifest '{ManifestPath}' not found; no sub-repo tags generated.");
                 return;
             }
 
@@ -74,7 +76,7 @@ namespace Microsoft.SourceIndexer.Tasks
             }
 
             RepoTags = tags.ToArray();
-            Log.LogMessage(MessageImportance.Normal, $"Generated {tags.Count} sub-repo tag(s) from '{ManifestPath}'.");
+            Log.LogMessage(MessageImportance.High, $"Generated {tags.Count} sub-repo tag(s) for the VMR.");
         }
 
         // Turns a clone URL into an owner/repo tag, matching the RepoDisplayName convention used for

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -699,14 +699,14 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             return assembly.GetName().Version?.ToString() ?? "unknown";
         }
 
-        // The generated site can run either through SourceIndexServer (which serves wwwroot/scripts.js
-        // as its baseline, byte-identical to the checked-in template) or as pure static files, where
-        // the copy under index/ -- and, at runtime, SourceIndexServer's own RootPath handler, which is
-        // registered ahead of its wwwroot handler -- is what's actually served. Both toggles below
-        // used to independently re-read wwwroot/scripts.js and overwrite index/scripts.js, which meant
-        // combining them (a federation alongside /showBranding) silently discarded whichever ran first.
-        // They're composed into one read-modify sequence here so any combination of flags ends up in
-        // the final file.
+        // scripts.js exists in two places in the generated output: wwwroot/ (the byte-identical checked-in
+        // template) and index/ (the finalized site under RootPath). The federation and /showBranding toggles
+        // below both read wwwroot/scripts.js and rewrite the placeholders. They must be written back to BOTH
+        // copies: SourceIndexServer's RootPath handler serves index/scripts.js when reachable, but the proxy
+        // deployment (Helpers.ServeProxiedIndex) deliberately serves scripts.js and the other chrome locally
+        // from wwwroot -- so writing only index/scripts.js let /showBranding (and federation URLs) silently
+        // fall back to the un-rewritten wwwroot copy on source.dot.net. Composed into one read-modify sequence
+        // so any combination of flags ends up in both files.
         private static void ApplyScriptsJsCustomizations(string destinationFolder, Federation federation, bool showBranding)
         {
             var source = Path.Combine(destinationFolder, "wwwroot/scripts.js");
@@ -745,8 +745,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             if (changed)
             {
-                var dst = Path.Combine(destinationFolder, "index/scripts.js");
-                File.WriteAllText(dst, text);
+                File.WriteAllText(source, text);
+                File.WriteAllText(Path.Combine(destinationFolder, "index/scripts.js"), text);
             }
         }
     }

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -118,6 +118,7 @@
       <ClonedRepositoryV2 Include="@(RepositoryV2)">
         <ServerPath>%(Url)/tree/$(CommitHash)/</ServerPath>
         <RepoDisplayName>$([System.String]::Copy('%(Url)').Replace('https://github.com/', ''))</RepoDisplayName>
+        <CommitSha>$(CommitHash)</CommitSha>
       </ClonedRepositoryV2>
     </ItemGroup>
   </Target>
@@ -180,12 +181,33 @@
 
   <!-- For VMR entries carrying a source manifest, emit one repo filter tag per subfolder so
        search can be scoped to the originating repo. Only /repoPath (filter) tags are added;
-       source links keep pointing at the top-level repo. -->
+       source links keep pointing at the top-level repo.
+
+       The stage1 bundle doesn't ship the VMR's src/source-manifest.json (it's not a project file),
+       so grab just that file from git at the pinned commit -- a treeless, single-file partial fetch,
+       keyed to the full dotnet-dotnet vertical's SHA (never dotnet-dotnet-windows). -->
   <Target Name="GenerateSubRepoTags" DependsOnTargets="ResolveHashV2"
           Outputs="%(ClonedRepositoryV2.Identity)">
+    <PropertyGroup>
+      <_ManifestDir>$(RepositoryPath)%(ClonedRepositoryV2.Identity)-manifest</_ManifestDir>
+    </PropertyGroup>
+    <RemoveDir Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+               Directories="$(_ManifestDir)"/>
+    <MakeDir Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+             Directories="$(_ManifestDir)"/>
+    <Exec Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+          Command="git init -q" WorkingDirectory="$(_ManifestDir)"/>
+    <Exec Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+          Command="git remote add origin %(ClonedRepositoryV2.Url).git" WorkingDirectory="$(_ManifestDir)"/>
+    <Exec Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+          Command="git -c protocol.version=2 fetch --depth 1 --filter=tree:0 origin %(ClonedRepositoryV2.CommitSha)"
+          WorkingDirectory="$(_ManifestDir)"/>
+    <Exec Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
+          Command="git show %(ClonedRepositoryV2.CommitSha):%(ClonedRepositoryV2.SubRepoManifest) &gt; source-manifest.json"
+          WorkingDirectory="$(_ManifestDir)"/>
     <GenerateVmrRepoTags
         Condition="'%(ClonedRepositoryV2.SubRepoManifest)' != ''"
-        ManifestPath="$([MSBuild]::NormalizePath('%(ClonedRepositoryV2.ExtractPath)', '%(ClonedRepositoryV2.SubRepoManifest)'))"
+        ManifestPath="$([MSBuild]::NormalizePath('$(_ManifestDir)', 'source-manifest.json'))"
         SrcRoot="$([MSBuild]::NormalizePath('%(ClonedRepositoryV2.ExtractPath)', 'src'))">
       <Output TaskParameter="RepoTags" ItemName="SubRepoTag"/>
     </GenerateVmrRepoTags>


### PR DESCRIPTION
Two source.dot.net fixes on top of #267.

----------

**Fetch the VMR source manifest from git for sub-repo tags**

The per-subfolder repo filter tags for the dotnet/dotnet VMR came up empty because the stage1 bundle doesn't ship `src/source-manifest.json` (it isn't a project file), and the extracted vertical can be the partial `dotnet-dotnet-windows` bundle. Fetch just that file from dotnet/dotnet at the pinned commit via a treeless single-file partial clone, keyed to the full `dotnet-dotnet` vertical's SHA rather than the windows one. Source links are unaffected — this only feeds `/repoPath` filtering.

----------

**Ensure `/showBranding` survives deployment**

The branding toggle was only rewritten into `index/scripts.js`, but the proxy serves `wwwroot/scripts.js` for site chrome, so the deployed site kept the raw `false` token. The rewrite now patches both copies.