### PR TITLE
Fix invalid '--' inside XML comment in index.proj

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -184,7 +184,7 @@
        source links keep pointing at the top-level repo.
 
        The stage1 bundle doesn't ship the VMR's src/source-manifest.json (it's not a project file),
-       so grab just that file from git at the pinned commit -- a treeless, single-file partial fetch,
+       so grab just that file from git at the pinned commit: a treeless, single-file partial fetch,
        keyed to the full dotnet-dotnet vertical's SHA (never dotnet-dotnet-windows). -->
   <Target Name="GenerateSubRepoTags" DependsOnTargets="ResolveHashV2"
           Outputs="%(ClonedRepositoryV2.Identity)">


### PR DESCRIPTION
The `GenerateSubRepoTags` comment added in #268 used a `--` aside inside an XML comment, which MSBuild rejects with `MSB4025` (an XML comment cannot contain `--`). This broke the index build:

```
index.proj(187,61): error MSB4025: The project file could not be loaded. An XML comment cannot contain '--', and '-' cannot be the last character.
```

Swapped the `--` for a colon. No behavior change; the project now loads and parses cleanly.