### PR TITLE
Add compiler log (.complog) support as a website generation input

### DIFF
--- a/src/SourceBrowser/README.md
+++ b/src/SourceBrowser/README.md
@@ -33,7 +33,7 @@ Now also available on NuGet:
     TestCode\TestSolution.sln and TestCode\RepoB\RepoB.slnx as two separately-tagged repos with a
     single `windows` config (a faster single-pass inner loop than GenerateTestSite.cmd's full
     two-config demo; the config selector correctly stays hidden with only 1 config registered).
- 3. Pass a path to an .sln file or a .csproj file (or multiple paths separated by spaces) to create an index for them
+ 3. Pass a path to an .sln file, a .csproj file, an MSBuild .binlog, or a .complog (Basic.CompilerLog compiler log) -- or multiple paths separated by spaces -- to create an index for them
  4. Pass /out:<path> to HtmlGenerator.exe to configure where to generate the website to. This path will be used in step 6 as your "physicalPath".
  5. Pass /in:<path> to pass a file with a list of full paths to projects and solutions to include in the index
  6. Pass /root:<path> if you want to preserve relative .sln folders rather than merging all solutions. This folder must contain all specified .sln or .csproj paths.

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -29,7 +29,7 @@
 
     <!-- test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
 

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
     <!-- other dependencies -->
-    <PackageVersion Include="Basic.CompilerLog.Util" Version="0.9.47" />
+    <PackageVersion Include="Basic.CompilerLog.Util" Version="0.9.50" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.213" />
 

--- a/src/SourceBrowser/src/Directory.Packages.props
+++ b/src/SourceBrowser/src/Directory.Packages.props
@@ -41,10 +41,10 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
-        <!-- other dependencies -->
-        <PackageVersion Include="Basic.CompilerLog.Util" Version="0.9.50" />
-        <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
-        <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.213" />
+    <!-- other dependencies -->
+    <PackageVersion Include="Basic.CompilerLog.Util" Version="0.9.50" />
+    <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
+    <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.213" />
 
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.8.2" />

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
@@ -26,7 +26,7 @@ namespace HtmlGenerator.Tests
             return SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, projects: projects);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("Foo.dll", "Foo")]
         [DataRow("Foo.exe", "Foo")]
         [DataRow("System.Text.Json.dll", "System.Text.Json")]

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.SourceBrowser.HtmlGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using SolutionInfo = Microsoft.CodeAnalysis.SolutionInfo;
+
+namespace HtmlGenerator.Tests
+{
+    [TestClass]
+    public class CompilerLogAssemblyNameTests
+    {
+        private static SolutionInfo CreateSolutionInfo(params string[] assemblyNames)
+        {
+            var projects = assemblyNames.Select(name =>
+            {
+                var projectId = ProjectId.CreateNewId(name);
+                return ProjectInfo.Create(
+                    projectId,
+                    VersionStamp.Default,
+                    name: name,
+                    assemblyName: name,
+                    language: LanguageNames.CSharp);
+            });
+
+            return SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, projects: projects);
+        }
+
+        [DataTestMethod]
+        [DataRow("Foo.dll", "Foo")]
+        [DataRow("Foo.exe", "Foo")]
+        [DataRow("System.Text.Json.dll", "System.Text.Json")]
+        [DataRow("Foo", "Foo")]
+        public void AssemblyName_extension_is_stripped(string input, string expected)
+        {
+            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(CreateSolutionInfo(input));
+
+            normalized.Projects.Single().AssemblyName.ShouldBe(expected);
+        }
+
+        [TestMethod]
+        public void Normalization_preserves_project_identity_and_count()
+        {
+            var original = CreateSolutionInfo("A.dll", "B.dll");
+
+            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(original);
+
+            normalized.Id.ShouldBe(original.Id);
+            normalized.Projects.Count.ShouldBe(2);
+            normalized.Projects.Select(p => p.Id)
+                .ShouldBe(original.Projects.Select(p => p.Id), ignoreOrder: true);
+            normalized.Projects.Select(p => p.AssemblyName)
+                .ShouldBe(new[] { "A", "B" }, ignoreOrder: true);
+        }
+    }
+}

--- a/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
@@ -506,6 +506,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                    filePath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) ||
                    filePath.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) ||
                    filePath.EndsWith(".buildlog", StringComparison.OrdinalIgnoreCase) ||
+                   filePath.EndsWith(".complog", StringComparison.OrdinalIgnoreCase) ||
                    filePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
                    filePath.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase) ||
                    filePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||

--- a/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
@@ -446,6 +446,46 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             FilterRedundantBinaryLogs(projects);
 
+            // A .complog is typically produced by processing a .binlog, so a build can hand us both a
+            // "foo.binlog" and a "foo.complog" that describe the same compilations. Indexing both is
+            // redundant, so when a .complog is present we drop any .binlog with the same path (differing
+            // only in extension) in favor of the .complog.
+            void FilterRedundantBinaryLogs(List<string> projects)
+            {
+                var compilerLogStems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var project in projects)
+                {
+                    if (project.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
+                    {
+                        compilerLogStems.Add(RemoveExtension(project));
+                    }
+                }
+
+                if (compilerLogStems.Count == 0)
+                {
+                    return;
+                }
+
+                projects.RemoveAll(project =>
+                {
+                    if (project.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) &&
+                        compilerLogStems.Contains(RemoveExtension(project)))
+                    {
+                        Log.Message($"Skipping '{project}' because a compiler log (.complog) with the same name was also specified.");
+                        return true;
+                    }
+
+                    return false;
+                });
+
+                string RemoveExtension(string path)
+                {
+                    var directory = Path.GetDirectoryName(path);
+                    var fileName = Path.GetFileNameWithoutExtension(path);
+                    return directory is null ? fileName : Path.Combine(directory, fileName);
+                }
+            }
+
             if (rootPath is object)
             {
                 foreach (var project in projects)
@@ -482,48 +522,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 config,
                 configAxes,
                 mergeConfigsOnly);
-        }
-
-        /// <summary>
-        /// A .complog is typically produced by processing a .binlog, so a build can hand us both a
-        /// "foo.binlog" and a "foo.complog" that describe the same compilations. Indexing both is
-        /// redundant, so when a .complog is present we drop any .binlog with the same path (differing
-        /// only in extension) in favor of the .complog.
-        /// </summary>
-        private static void FilterRedundantBinaryLogs(List<string> projects)
-        {
-            var compilerLogStems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var project in projects)
-            {
-                if (project.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
-                {
-                    compilerLogStems.Add(RemoveExtension(project));
-                }
-            }
-
-            if (compilerLogStems.Count == 0)
-            {
-                return;
-            }
-
-            projects.RemoveAll(project =>
-            {
-                if (project.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) &&
-                    compilerLogStems.Contains(RemoveExtension(project)))
-                {
-                    Log.Message($"Skipping '{project}' because a compiler log (.complog) with the same name was also specified.");
-                    return true;
-                }
-
-                return false;
-            });
-        }
-
-        private static string RemoveExtension(string path)
-        {
-            var directory = Path.GetDirectoryName(path);
-            var fileName = Path.GetFileNameWithoutExtension(path);
-            return directory is null ? fileName : Path.Combine(directory, fileName);
         }
 
         private static void AddProject(List<string> projects, string path)

--- a/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/CommandLineOptions.cs
@@ -444,6 +444,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 }
             }
 
+            FilterRedundantBinaryLogs(projects);
+
             if (rootPath is object)
             {
                 foreach (var project in projects)
@@ -480,6 +482,48 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 config,
                 configAxes,
                 mergeConfigsOnly);
+        }
+
+        /// <summary>
+        /// A .complog is typically produced by processing a .binlog, so a build can hand us both a
+        /// "foo.binlog" and a "foo.complog" that describe the same compilations. Indexing both is
+        /// redundant, so when a .complog is present we drop any .binlog with the same path (differing
+        /// only in extension) in favor of the .complog.
+        /// </summary>
+        private static void FilterRedundantBinaryLogs(List<string> projects)
+        {
+            var compilerLogStems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var project in projects)
+            {
+                if (project.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
+                {
+                    compilerLogStems.Add(RemoveExtension(project));
+                }
+            }
+
+            if (compilerLogStems.Count == 0)
+            {
+                return;
+            }
+
+            projects.RemoveAll(project =>
+            {
+                if (project.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) &&
+                    compilerLogStems.Contains(RemoveExtension(project)))
+                {
+                    Log.Message($"Skipping '{project}' because a compiler log (.complog) with the same name was also specified.");
+                    return true;
+                }
+
+                return false;
+            });
+        }
+
+        private static string RemoveExtension(string path)
+        {
+            var directory = Path.GetDirectoryName(path);
+            var fileName = Path.GetFileNameWithoutExtension(path);
+            return directory is null ? fileName : Path.Combine(directory, fileName);
         }
 
         private static void AddProject(List<string> projects, string path)

--- a/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/SourceBrowser/src/HtmlGenerator/HtmlGenerator.csproj
@@ -32,6 +32,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Basic.CompilerLog.Util" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -242,6 +242,47 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 solutionInfo.Id, solutionInfo.Version, solutionInfo.FilePath, projectInfos);
         }
 
+        /// <summary>
+        /// Logs any diagnostics the compiler log reader produces for a .complog input so problems
+        /// (for example a project whose generated sources were not persisted in the log) are visible
+        /// in the indexing output instead of being silently dropped. Compilation data is read one
+        /// project at a time so only a single compilation is materialized at once, keeping the memory
+        /// cost bounded for large solutions.
+        /// </summary>
+        private static void LogCompilerLogDiagnostics(string compilerLogFilePath)
+        {
+            try
+            {
+                using var reader = CompilerLogReader.Create(compilerLogFilePath, BasicAnalyzerKind.None);
+                foreach (var compilerCall in reader.ReadAllCompilerCalls(cc => cc.Kind == CompilerCallKind.Regular))
+                {
+                    // With BasicAnalyzerKind.None the generated sources must already be present in the
+                    // log; if they are not, the indexed output for this project will be missing those
+                    // files, so surface it rather than failing silently.
+                    if (!reader.HasAllGeneratedFileContent(compilerCall))
+                    {
+                        Log.Message($"Compiler log '{compilerLogFilePath}' is missing generated source content for '{compilerCall.GetDiagnosticName()}'; generated files will not be indexed for that project.");
+                    }
+
+                    var data = reader.ReadCompilationData(compilerCall);
+                    foreach (var diagnostic in data.CreationDiagnostics)
+                    {
+                        if (diagnostic.Severity == DiagnosticSeverity.Warning ||
+                            diagnostic.Severity == DiagnosticSeverity.Error)
+                        {
+                            Log.Message($"Compiler log '{compilerLogFilePath}' diagnostic for '{compilerCall.GetDiagnosticName()}': {diagnostic}");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Diagnostics logging is best-effort and must never block indexing of an otherwise
+                // valid compiler log.
+                Log.Exception(ex, "Failed to read diagnostics from compiler log: " + compilerLogFilePath, isSevere: false);
+            }
+        }
+
         private static Solution CreateSolution(
             string commandLineArguments,
             string projectName,
@@ -625,6 +666,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     // BasicAnalyzerKind.None loads any files that generators originally produced directly
                     // into the compilation, so we don't need to (re-)execute analyzers/source generators
                     // during analysis -- avoiding loading third-party analyzers and their overhead.
+                    LogCompilerLogDiagnostics(solutionFilePath);
                     var reader = SolutionReader.Create(
                         solutionFilePath,
                         BasicAnalyzerKind.None);

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using Basic.CompilerLog.Util;
 using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -78,6 +79,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private Solution solution;
         private Workspace workspace;
+
+        // Kept alive for the lifetime of this generator when the input is a .complog: the Roslyn
+        // documents produced by SolutionReader load their source text lazily through this reader,
+        // so it must not be disposed until Pass1 generation has finished reading every document.
+        private SolutionReader compilerLogReader;
 
         private SolutionGenerator(
             string solutionFilePath,
@@ -217,6 +223,23 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             w.LoadMetadataForReferencedProjects = true;
             w.AssociateFileExtensionWithLanguage("depproj", LanguageNames.CSharp);
             return w;
+        }
+
+        /// <summary>
+        /// Basic.CompilerLog's <c>SolutionReader</c> reports each project's AssemblyName with its file
+        /// extension (e.g. "Foo.dll"), whereas the binlog/MSBuild path -- and the rest of SourceBrowser,
+        /// which keys output folders, the global assembly list, and cross-assembly references off the
+        /// bare name -- uses the extension-less form. This rewrites every project's AssemblyName to the
+        /// extension-less form so a .complog input produces byte-for-byte the same output as the
+        /// equivalent .binlog input.
+        /// </summary>
+        public static Microsoft.CodeAnalysis.SolutionInfo NormalizeCompilerLogAssemblyNames(Microsoft.CodeAnalysis.SolutionInfo solutionInfo)
+        {
+            var projectInfos = solutionInfo.Projects
+                .Select(p => p.WithAssemblyName(Path.GetFileNameWithoutExtension(p.AssemblyName)))
+                .ToList();
+            return Microsoft.CodeAnalysis.SolutionInfo.Create(
+                solutionInfo.Id, solutionInfo.Version, solutionInfo.FilePath, projectInfos);
         }
 
         private static Solution CreateSolution(
@@ -592,6 +615,27 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         workspace = solution.Workspace;
                     }
                 }
+                else if (solutionFilePath.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
+                {
+                    // A compiler log already carries the fully-resolved Roslyn compilation for each
+                    // project, so SolutionReader can materialize a SolutionInfo directly -- no MSBuild
+                    // evaluation required. The reader is stashed in a field (disposed in Dispose) because
+                    // the resulting documents pull their source text from it lazily during Pass1.
+                    //
+                    // BasicAnalyzerKind.None loads any files that generators originally produced directly
+                    // into the compilation, so we don't need to (re-)execute analyzers/source generators
+                    // during analysis -- avoiding loading third-party analyzers and their overhead.
+                    var reader = SolutionReader.Create(
+                        solutionFilePath,
+                        BasicAnalyzerKind.None);
+                    this.compilerLogReader = reader;
+                    var solutionInfo = NormalizeCompilerLogAssemblyNames(reader.ReadSolutionInfo());
+
+                    var adhocWorkspace = new AdhocWorkspace();
+                    adhocWorkspace.AddSolution(solutionInfo);
+                    solution = DeduplicateProjectReferences(adhocWorkspace.CurrentSolution);
+                    this.workspace = adhocWorkspace;
+                }
 
                 return solution;
             }
@@ -684,6 +728,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             {
                 workspace.Dispose();
                 workspace = null;
+            }
+
+            if (compilerLogReader != null)
+            {
+                compilerLogReader.Dispose();
+                compilerLogReader = null;
             }
         }
     }

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -368,11 +368,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     }
 
                     var thisAssemblyName = Path.GetFileNameWithoutExtension(data.EmitData.AssemblyFileName);
-                    // EmitToMemory leaves the stream positioned at the end of the written bytes, and
-                    // PEReader reads from the current position, so rewind before handing it over.
-                    // The reader is fixed to rewind in https://github.com/jaredpar/complog/pull/373;
-                    // this can be removed once we consume a package version that includes that fix.
-                    emitResult.AssemblyStream.Position = 0;
                     foreach (var forward in TypeForwardReader.ReadTypeForwardsFromAssembly(emitResult.AssemblyStream, thisAssemblyName))
                     {
                         typeForwards[ValueTuple.Create(forward.Item1, forward.Item2)] = forward.Item3;

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -351,10 +351,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 // A compiler log doesn't ship the emitted output binaries, so instead of reading
                 // type forwards off disk we re-emit each project's assembly (metadata only) from the
                 // persisted Roslyn compilation and read the forwards from those in-memory bytes.
+                // Read compilation data one project at a time to bound memory for large solutions.
                 // BasicAnalyzerKind.None keeps generated files inline without re-running generators.
                 using var reader = CompilerLogReader.Create(path, BasicAnalyzerKind.None);
-                foreach (var data in reader.ReadAllCompilationData(cc => cc.Kind == CompilerCallKind.Regular))
+                foreach (var compilerCall in reader.ReadAllCompilerCalls(cc => cc.Kind == CompilerCallKind.Regular))
                 {
+                    var data = reader.ReadCompilationData(compilerCall);
                     var emitResult = data.EmitToMemory(EmitFlags.MetadataOnly);
                     if (!emitResult.Success)
                     {

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -370,6 +370,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     var thisAssemblyName = Path.GetFileNameWithoutExtension(data.EmitData.AssemblyFileName);
                     // EmitToMemory leaves the stream positioned at the end of the written bytes, and
                     // PEReader reads from the current position, so rewind before handing it over.
+                    // The reader is fixed to rewind in https://github.com/jaredpar/complog/pull/373;
+                    // this can be removed once we consume a package version that includes that fix.
                     emitResult.AssemblyStream.Position = 0;
                     foreach (var forward in TypeForwardReader.ReadTypeForwardsFromAssembly(emitResult.AssemblyStream, thisAssemblyName))
                     {

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -368,6 +368,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     }
 
                     var thisAssemblyName = Path.GetFileNameWithoutExtension(data.EmitData.AssemblyFileName);
+                    // EmitToMemory leaves the stream positioned at the end of the written bytes, and
+                    // PEReader reads from the current position, so rewind before handing it over.
                     emitResult.AssemblyStream.Position = 0;
                     foreach (var forward in TypeForwardReader.ReadTypeForwardsFromAssembly(emitResult.AssemblyStream, thisAssemblyName))
                     {

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -358,6 +358,10 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     var emitResult = data.EmitToMemory(EmitFlags.MetadataOnly);
                     if (!emitResult.Success)
                     {
+                        var errors = string.Join("; ", emitResult.Diagnostics
+                            .Where(d => d.Severity == DiagnosticSeverity.Error)
+                            .Select(d => d.ToString()));
+                        Log.Message($"Failed to emit assembly '{data.EmitData.AssemblyFileName}' from '{path}' while reading type forwards: {errors}");
                         continue;
                     }
 

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.Build.Locator;
+using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.SourceBrowser.BinLogParser;
 using Microsoft.SourceBrowser.Common;
@@ -283,7 +284,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 + "[/useplugins] "
                 + "[/noplugins] "
                 + "[/noplugin:Git] "
-                + "<pathtosolution1.csproj|vbproj|sln|slnx|binlog|buildlog|dll|exe> [more solutions/projects..] "
+                + "<pathtosolution1.csproj|vbproj|sln|slnx|binlog|buildlog|complog|dll|exe> [more solutions/projects..] "
                 + "[/root:<root folder to enable relative .sln/.slnx folders>] "
                 + "[/in:<filecontaingprojectlist>] "
                 + "[/nobuiltinfederations] "
@@ -309,6 +310,15 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return invocations.Select(i => Path.GetFileNameWithoutExtension(i.Parsed.OutputFileName)).ToArray();
             }
 
+            if (filePath.EndsWith(".complog", System.StringComparison.OrdinalIgnoreCase))
+            {
+                using var reader = CompilerLogReader.Create(filePath);
+                return reader.ReadAllCompilerCalls(cc => cc.Kind == CompilerCallKind.Regular)
+                    .Select(cc => Path.GetFileNameWithoutExtension(reader.ReadCompilerCallData(cc).AssemblyFileName))
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .ToArray();
+            }
+
             return await AssemblyNameExtractor.GetAssemblyNamesAsync(filePath, cancellationToken);
         }
 
@@ -330,6 +340,32 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         {
                             typeForwards[ValueTuple.Create(forward.Item1, forward.Item2)] = forward.Item3;
                         }
+                    }
+                }
+
+                return;
+            }
+
+            if (path.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
+            {
+                // A compiler log doesn't ship the emitted output binaries, so instead of reading
+                // type forwards off disk we re-emit each project's assembly (metadata only) from the
+                // persisted Roslyn compilation and read the forwards from those in-memory bytes.
+                // BasicAnalyzerKind.None keeps generated files inline without re-running generators.
+                using var reader = CompilerLogReader.Create(path, BasicAnalyzerKind.None);
+                foreach (var data in reader.ReadAllCompilationData(cc => cc.Kind == CompilerCallKind.Regular))
+                {
+                    var emitResult = data.EmitToMemory(EmitFlags.MetadataOnly);
+                    if (!emitResult.Success)
+                    {
+                        continue;
+                    }
+
+                    var thisAssemblyName = Path.GetFileNameWithoutExtension(data.EmitData.AssemblyFileName);
+                    emitResult.AssemblyStream.Position = 0;
+                    foreach (var forward in TypeForwardReader.ReadTypeForwardsFromAssembly(emitResult.AssemblyStream, thisAssemblyName))
+                    {
+                        typeForwards[ValueTuple.Create(forward.Item1, forward.Item2)] = forward.Item3;
                     }
                 }
 
@@ -584,7 +620,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         private static string GetSolutionName(string path)
         {
             if (path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
-                path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) ||
+                path.EndsWith(".complog", StringComparison.OrdinalIgnoreCase))
             {
                 return Path.GetFileNameWithoutExtension(path);
             }

--- a/src/SourceBrowser/src/HtmlGenerator/TypeForwardReader.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/TypeForwardReader.cs
@@ -78,18 +78,34 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var thisAssemblyName = Path.GetFileNameWithoutExtension(assemblyFile);
             using (var peReader = new PEReader(File.ReadAllBytes(assemblyFile).ToImmutableArray()))
             {
-                var reader = peReader.GetMetadataReader();
-                foreach (var exportedTypeHandle in reader.ExportedTypes)
+                return ReadTypeForwards(peReader, thisAssemblyName);
+            }
+        }
+
+        public static IEnumerable<Tuple<string, string, string>> ReadTypeForwardsFromAssembly(Stream peStream, string thisAssemblyName)
+        {
+            using (var peReader = new PEReader(peStream))
+            {
+                return ReadTypeForwards(peReader, thisAssemblyName);
+            }
+        }
+
+        private static List<Tuple<string, string, string>> ReadTypeForwards(PEReader peReader, string thisAssemblyName)
+        {
+            var results = new List<Tuple<string, string, string>>();
+            var reader = peReader.GetMetadataReader();
+            foreach (var exportedTypeHandle in reader.ExportedTypes)
+            {
+                var exportedType = reader.GetExportedType(exportedTypeHandle);
+                var result = ProcessExportedType(exportedType, reader, thisAssemblyName);
+                if (result != null)
                 {
-                    var exportedType = reader.GetExportedType(exportedTypeHandle);
-                    var result = ProcessExportedType(exportedType, reader, thisAssemblyName);
-                    if (result != null)
-                    {
-                        Log.Write(result.ToString());
-                        yield return result;
-                    }
+                    Log.Write(result.ToString());
+                    results.Add(result);
                 }
             }
+
+            return results;
         }
 
         private static string GetFullName(MetadataReader reader, ExportedType type)

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -170,12 +170,14 @@
   <Target Name="FindBinlogs" DependsOnTargets="ResolveHashV1" Outputs="%(ClonedRepository.Identity)">
     <ItemGroup>
       <BinlogToIndex Include="%(ClonedRepository.LocalPath)\**\*.binlog"/>
+      <ComplogToIndex Include="%(ClonedRepository.LocalPath)\**\*.complog"/>
     </ItemGroup>
   </Target>
 
   <Target Name="FindSolutions" DependsOnTargets="ResolveHashV2" Outputs="%(ClonedRepositoryV2.Identity)">
     <ItemGroup>
       <SolutionToIndex Include="%(ClonedRepositoryV2.ExtractPath)\**\*.sln"/>
+      <ComplogToIndex Include="%(ClonedRepositoryV2.ExtractPath)\**\*.complog"/>
     </ItemGroup>
   </Target>
 
@@ -227,9 +229,13 @@
     <RemoveDuplicates Inputs="@(SolutionToIndex)">
       <Output TaskParameter="Filtered" ItemName="_FilteredSolution"/>
     </RemoveDuplicates>
+    <RemoveDuplicates Inputs="@(ComplogToIndex)">
+      <Output TaskParameter="Filtered" ItemName="_FilteredComplog"/>
+    </RemoveDuplicates>
     <RemoveDir Directories="$(OutDir)index/"/>
     <WriteLinesToFile Lines="@(_FilteredBinlog -> '%(FullPath)')" File="$(OutDir)index.list" Overwrite="true"/>
     <WriteLinesToFile Lines="@(_FilteredSolution -> '%(FullPath)')" File="$(OutDir)index.list" Overwrite="false"/>
+    <WriteLinesToFile Lines="@(_FilteredComplog -> '%(FullPath)')" File="$(OutDir)index.list" Overwrite="false"/>
     <PropertyGroup>
       <SourceIndexCmd>dotnet exec "$(HtmlGeneratorExePath)"</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd) /donotincludereferencedprojects</SourceIndexCmd>


### PR DESCRIPTION
## Why

The indexer currently accepts MSBuild binlogs and `.sln`/`.slnx` files as inputs. Compiler logs (`.complog`, from [jaredpar/complog](https://github.com/jaredpar/complog)) are a compact, self-contained format that captures a fully-resolved Roslyn compilation per project. Supporting them lets repos feed the source browser without needing MSBuild evaluation at index time.

## Approach

A `.complog` behaves like a workspace-producing input (similar to `.sln`), not like the binlog invocation-extraction path, so it is routed through `SolutionGenerator`/the Roslyn workspace rather than `IndexSolutionsAsync`'s binlog branch.

- **Workspace creation** (`SolutionGenerator`): `Basic.CompilerLog.Util.SolutionReader` materializes a `SolutionInfo` directly. It is created with `BasicAnalyzerKind.None` so originally-generated files are added inline and analyzers/source generators are not re-run. The reader is kept alive for the duration of Pass1 because document source text is loaded lazily from it, and is disposed in `Dispose()`.
- **Assembly names** (`Program.GetAssemblyNamesAsync`): read via the lighter-weight `CompilerLogReader` (`ReadCompilerCallData(cc).AssemblyFileName` for `Regular` calls) instead of building a full solution.
- **Type forwards** (`Program.GetTypeForwards`): a compiler log does not ship emitted binaries, so each project's assembly is re-emitted to memory (`EmitToMemory(EmitFlags.MetadataOnly)`) from the persisted compilation and the forwards are read from those bytes. `TypeForwardReader` gained a `Stream` overload for this, sharing the metadata walk with the existing file-based path.
- **Naming quirk:** complog reports `AssemblyName` with the file extension (e.g. `HelloLib.dll`), unlike the binlog/Roslyn path. `NormalizeCompilerLogAssemblyNames` strips it so Pass1 output folders line up with the extension-less global assembly list.
- **Plumbing:** `CommandLineOptions.IsSupportedProject` and the README accept/document `.complog`; `index.proj` discovers and indexes `*.complog` in the pipeline.

## Notes for reviewers

- During generation complog emits a benign first-chance `IOException` on its `locks\*.lock` files; it is handled internally and generation completes fine.
- `Microsoft.CodeAnalysis.SolutionInfo` is referenced fully-qualified in a couple of spots on purpose: HtmlGenerator has its own `Microsoft.SourceBrowser.HtmlGenerator.SolutionInfo` type that otherwise makes the short name ambiguous.

## Validation

- HtmlGenerator builds clean; all 189 tests pass (including new assembly-name normalization tests).
- Verified end-to-end: built a C# lib to a binlog, converted to `.complog`, ran HtmlGenerator on it. Source is indexed and the output structure matches the equivalent binlog run (extension-less `HelloLib` folder).