### PR TITLE
Avoid requiring PDBs in complogs

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogTypeForwardTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogTypeForwardTests.cs
@@ -1,0 +1,50 @@
+using Basic.CompilerLog.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.SourceBrowser.HtmlGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace HtmlGenerator.Tests;
+
+[TestClass]
+public sealed class CompilerLogTypeForwardTests
+{
+    [TestMethod]
+    public void Metadata_emit_omits_pdb_only_compiler_log_data()
+    {
+        var sourceText = SourceText.From("public class C { }", Encoding.UTF8);
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: "Embedded.cs");
+        var compilation = CSharpCompilation.Create(
+            "Embedded",
+            [syntaxTree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var sourceLinkStream = new MemoryStream(Encoding.UTF8.GetBytes("""{"documents":{}}"""));
+        var emitData = new EmitData(
+            assemblyFileName: "Embedded.dll",
+            xmlFilePath: null,
+            emitPdb: true,
+            win32ResourceStream: null,
+            sourceLinkStream,
+            resources: null,
+            embeddedTexts: [EmbeddedText.FromSource(syntaxTree.FilePath, sourceText)]);
+
+        var result = Program.EmitMetadataForTypeForwards(
+            compilation,
+            emitData,
+            new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
+        using var assemblyStream = result.AssemblyStream;
+        using var pdbStream = result.PdbStream;
+
+        result.Success.ShouldBeTrue(string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
+        assemblyStream.Length.ShouldBeGreaterThan(0);
+        pdbStream.ShouldBeNull();
+    }
+}

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -16,6 +16,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Emit;
+
+[assembly: InternalsVisibleTo("HtmlGenerator.Tests")]
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
@@ -357,12 +360,24 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 foreach (var compilerCall in reader.ReadAllCompilerCalls(cc => cc.Kind == CompilerCallKind.Regular))
                 {
                     var data = reader.ReadCompilationData(compilerCall);
-                    var emitResult = data.EmitToMemory(EmitFlags.MetadataOnly);
+                    var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
+                    if (diagnostics.Any(static d => d.Severity == DiagnosticSeverity.Error))
+                    {
+                        var errors = string.Join("; ", diagnostics
+                            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+                            .Select(static d => d.ToString()));
+                        Log.Message($"Failed to emit assembly '{data.EmitData.AssemblyFileName}' from '{path}' while reading type forwards: {errors}");
+                        continue;
+                    }
+
+                    // Source Link and embedded texts require a PDB, which metadata-only emits cannot
+                    // produce. They are not needed to read type forwards, so omit them here.
+                    var emitResult = EmitMetadataForTypeForwards(compilation, data.EmitData, data.EmitOptions);
                     if (!emitResult.Success)
                     {
-                        var errors = string.Join("; ", emitResult.Diagnostics
-                            .Where(d => d.Severity == DiagnosticSeverity.Error)
-                            .Select(d => d.ToString()));
+                        var errors = string.Join("; ", diagnostics.Concat(emitResult.Diagnostics)
+                            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+                            .Select(static d => d.ToString()));
                         Log.Message($"Failed to emit assembly '{data.EmitData.AssemblyFileName}' from '{path}' while reading type forwards: {errors}");
                         continue;
                     }
@@ -385,6 +400,18 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     typeForwards[ValueTuple.Create(forward.Item1, forward.Item2)] = forward.Item3;
                 }
             }
+        }
+
+        internal static EmitMemoryResult EmitMetadataForTypeForwards(
+            Compilation compilation,
+            EmitData emitData,
+            EmitOptions emitOptions)
+        {
+            return compilation.EmitToMemory(
+                EmitFlags.MetadataOnly,
+                win32ResourceStream: emitData.Win32ResourceStream,
+                manifestResources: emitData.Resources,
+                emitOptions: emitOptions);
         }
 
         private static async Task IndexSolutionsAsync(


### PR DESCRIPTION
See:
- failure before: https://dev.azure.com/dnceng/internal/_build/results?buildId=3044731&view=results
- success after: https://dev.azure.com/dnceng/internal/_build/results?buildId=3044770&view=results