### PR TITLE
Fix source search aliases, operators, and repo filtering

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator.Tests/ClassifierTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/ClassifierTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.SourceBrowser.HtmlGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
+{
+    [TestClass]
+    public class ClassifierTests
+    {
+        [TestMethod]
+        [DataRow("struct S { public static S operator +(S left, S right) => left; }")]
+        [DataRow("struct S { public static implicit operator int(S value) => 0; }")]
+        public async Task OperatorDeclarationsAreLinkable(string source)
+        {
+            using var workspace = new AdhocWorkspace();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var solution = workspace.CurrentSolution
+                .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                .WithProjectCompilationOptions(
+                    projectId,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .AddDocument(
+                    documentId,
+                    "Operator.cs",
+                    source);
+            var document = solution.GetDocument(documentId);
+            var classifier = new Classification();
+            var text = await document.GetTextAsync();
+
+            var ranges = (await classifier.ClassifyAsync(document, text)).ToArray();
+
+            Assert.AreEqual(Constants.ClassificationKeyword, ranges.Single(r => r.Text == "operator").ClassificationType);
+        }
+
+        [TestMethod]
+        [DataRow("OPERATOR")]
+        [DataRow("OpErAtOr")]
+        public async Task VisualBasicOperatorDeclarationsAreLinkable(string operatorKeyword)
+        {
+            using var workspace = new AdhocWorkspace();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var solution = workspace.CurrentSolution
+                .AddProject(projectId, "TestProject", "TestProject", LanguageNames.VisualBasic)
+                .WithProjectCompilationOptions(
+                    projectId,
+                    new Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions(
+                        OutputKind.DynamicallyLinkedLibrary))
+                .AddDocument(
+                    documentId,
+                    "Operator.vb",
+                    $"Structure S\nPublic Shared {operatorKeyword} +(value As S) As S\nReturn value\nEnd Operator\nEnd Structure");
+            var document = solution.GetDocument(documentId);
+            var classifier = new Classification();
+            var text = await document.GetTextAsync();
+
+            var ranges = (await classifier.ClassifyAsync(document, text)).ToArray();
+
+            Assert.AreEqual(
+                Constants.ClassificationKeyword,
+                ranges.Single(r => r.Text == operatorKeyword).ClassificationType);
+        }
+
+        [TestMethod]
+        public async Task ConversionOperatorNamesUseSearchableSyntax()
+        {
+            using var workspace = new AdhocWorkspace();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var solution = workspace.CurrentSolution
+                .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                .WithProjectCompilationOptions(
+                    projectId,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .AddDocument(
+                    documentId,
+                    "Decimal32.cs",
+                    "struct Decimal32 { public static explicit operator Decimal32(decimal value) => default; }");
+            var document = solution.GetDocument(documentId);
+            var root = await document.GetSyntaxRootAsync();
+            var semanticModel = await document.GetSemanticModelAsync();
+            var declaration = root.DescendantNodes().OfType<ConversionOperatorDeclarationSyntax>().Single();
+            var symbol = semanticModel.GetDeclaredSymbol(declaration);
+
+            Assert.AreEqual("explicit operator Decimal32", SymbolIdService.GetName(symbol));
+        }
+    }
+}

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/ClassifierTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/ClassifierTests.cs
@@ -89,5 +89,23 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
 
             Assert.AreEqual("explicit operator Decimal32", SymbolIdService.GetName(symbol));
         }
+
+        [TestMethod]
+        public void IndexedSpecialTypeNamesMatchSearchAliases()
+        {
+            var compilation = CSharpCompilation.Create(
+                "Test",
+                new[] { CSharpSyntaxTree.ParseText("class C { int i; nint n; }") },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+            var fields = compilation.GetTypeByMetadataName("C").GetMembers().OfType<IFieldSymbol>();
+
+            Assert.AreEqual(
+                "System.Int32",
+                SymbolIdService.GetDisplayString(fields.Single(f => f.Name == "i").Type));
+            Assert.AreEqual(
+                "nint",
+                SymbolIdService.GetDisplayString(fields.Single(f => f.Name == "n").Type));
+        }
+
     }
 }

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/FederationTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/FederationTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using Microsoft.SourceBrowser.HtmlGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
+{
+    [TestClass]
+    public class FederationTests
+    {
+        [TestMethod]
+        [DataRow(false, "System.Runtime/A.html#8281103e6f23cb5c")]
+        [DataRow(true, "api/symbolredirect?symbolId=8281103e6f23cb5c")]
+        public void ExternalSymbolPathUsesAdvertisedResolver(bool supportsSymbolRedirect, string expected)
+        {
+            string assemblyListFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(assemblyListFile, "System.Runtime");
+                var federation = new Federation();
+                federation.AddFederation(
+                    "https://source.example/",
+                    assemblyListFile,
+                    supportsSymbolRedirect);
+
+                Assert.AreEqual(
+                    expected,
+                    federation.GetExternalSymbolPath(
+                        externalAssemblyIndex: 0,
+                        "System.Runtime",
+                        "8281103e6f23cb5c"));
+            }
+            finally
+            {
+                File.Delete(assemblyListFile);
+            }
+        }
+    }
+}

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Classifier.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Classifier.cs
@@ -116,8 +116,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private static bool IsOperatorKeyword(string text)
         {
-            return text.Length == "operator".Length &&
-                text.Equals("operator", StringComparison.OrdinalIgnoreCase);
+            return text.Equals("operator", StringComparison.OrdinalIgnoreCase);
         }
 
         private IEnumerable<Range> FillGaps(SourceText text, IEnumerable<Range> spans)

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Classifier.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Classifier.cs
@@ -103,13 +103,21 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         private static bool IsMergeable(Range span)
         {
             return span.ClassificationType == Constants.RoslynClassificationKeyword &&
-                span.Text != "this" &&
-                span.Text != "base" &&
-                span.Text != "New" &&
-                span.Text != "new" &&
-                span.Text != "var" &&
-                span.Text != "partial" &&
-                span.Text != "Partial";
+                span.Text is not (
+                    "this" or
+                    "base" or
+                    "New" or
+                    "new" or
+                    "var" or
+                    "partial" or
+                    "Partial") &&
+                !IsOperatorKeyword(span.Text);
+        }
+
+        private static bool IsOperatorKeyword(string text)
+        {
+            return text.Length == "operator".Length &&
+                text.Equals("operator", StringComparison.OrdinalIgnoreCase);
         }
 
         private IEnumerable<Range> FillGaps(SourceText text, IEnumerable<Range> spans)

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
@@ -23,8 +23,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             if (range.ClassificationType != Constants.ClassificationIdentifier &&
                 range.ClassificationType != Constants.ClassificationTypeName)
             {
-                isOperatorKeyword = text.Length == "operator".Length &&
-                    text.Equals("operator", StringComparison.OrdinalIgnoreCase);
+                isOperatorKeyword = text.Equals("operator", StringComparison.OrdinalIgnoreCase);
                 if (!isOperatorKeyword &&
                     text is not (
                         "this" or
@@ -45,9 +44,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var position = range.ClassifiedSpan.TextSpan.Start;
             var token = Root.FindToken(position, findInsideTrivia: true);
             if (isOperatorKeyword &&
-                token.Parent is not OperatorDeclarationSyntax &&
-                token.Parent is not ConversionOperatorDeclarationSyntax &&
-                token.Parent is not Microsoft.CodeAnalysis.VisualBasic.Syntax.OperatorStatementSyntax)
+                token.Parent is not OperatorDeclarationSyntax and not
+                    ConversionOperatorDeclarationSyntax and not
+                    Microsoft.CodeAnalysis.VisualBasic.Syntax.OperatorStatementSyntax)
             {
                 return null;
             }

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
@@ -19,24 +19,39 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return TryProcessGuid(range);
             }
 
+            bool isOperatorKeyword = false;
             if (range.ClassificationType != Constants.ClassificationIdentifier &&
-                range.ClassificationType != Constants.ClassificationTypeName &&
-                text != "this" &&
-                text != "base" &&
-                text != "string" &&
-                text != "var" &&
-                text != "New" &&
-                text != "new" &&
-                text != "[" &&
-                text != "partial" &&
-                text != "Partial" &&
-                text != "extension")
+                range.ClassificationType != Constants.ClassificationTypeName)
             {
-                return null;
+                isOperatorKeyword = text.Length == "operator".Length &&
+                    text.Equals("operator", StringComparison.OrdinalIgnoreCase);
+                if (!isOperatorKeyword &&
+                    text is not (
+                        "this" or
+                        "base" or
+                        "string" or
+                        "var" or
+                        "New" or
+                        "new" or
+                        "[" or
+                        "partial" or
+                        "Partial" or
+                        "extension"))
+                {
+                    return null;
+                }
             }
 
             var position = range.ClassifiedSpan.TextSpan.Start;
             var token = Root.FindToken(position, findInsideTrivia: true);
+            if (isOperatorKeyword &&
+                token.Parent is not OperatorDeclarationSyntax &&
+                token.Parent is not ConversionOperatorDeclarationSyntax &&
+                token.Parent is not Microsoft.CodeAnalysis.VisualBasic.Syntax.OperatorStatementSyntax)
+            {
+                return null;
+            }
+
             if (IsZeroLengthArrayAllocation(token))
             {
                 projectGenerator.AddReference(

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.References.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.References.cs
@@ -674,12 +674,10 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 string href = "@" +
                     externalAssemblyIndex.ToString() +
                     "@" +
-                    assemblyName +
-                    "/" +
-                    Constants.IDResolvingFileName +
-                    ".html" +
-                    "#" +
-                    symbolId;
+                    projectGenerator.SolutionGenerator.GetExternalSymbolPath(
+                        externalAssemblyIndex,
+                        assemblyName,
+                        symbolId);
 
                 return new HtmlElementInfo
                 {

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Federation.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/Federation.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
@@ -24,7 +26,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private class Info
         {
-            public Info(string server, HashSet<string> assemblies)
+            public Info(string server, HashSet<string> assemblies, bool supportsSymbolRedirect)
             {
                 if (server == null)
                 {
@@ -38,10 +40,18 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
                 Server = server;
                 Assemblies = assemblies ?? throw new ArgumentNullException(nameof(assemblies));
+                SupportsSymbolRedirect = supportsSymbolRedirect;
             }
 
             public string Server { get; }
             public HashSet<string> Assemblies { get; }
+            public bool SupportsSymbolRedirect { get; }
+        }
+
+        private sealed class Capabilities
+        {
+            [JsonPropertyName("symbolRedirect")]
+            public bool SymbolRedirect { get; set; }
         }
 
         private readonly List<Info> federations = new List<Info>();
@@ -83,16 +93,47 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var assemblyList = httpClient.GetStringAsync(url).GetAwaiter().GetResult();
             var assemblyNames = GetAssemblyNames(assemblyList);
+            bool supportsSymbolRedirect = GetSupportsSymbolRedirect(server);
 
-            federations.Add(new Info(server, assemblyNames));
+            federations.Add(new Info(server, assemblyNames, supportsSymbolRedirect));
         }
 
         public void AddFederation(string server, string assemblyListFile)
         {
+            AddFederation(server, assemblyListFile, supportsSymbolRedirect: false);
+        }
+
+        internal void AddFederation(
+            string server,
+            string assemblyListFile,
+            bool supportsSymbolRedirect)
+        {
             var fileText = File.ReadAllText(assemblyListFile);
             var assemblyNames = GetAssemblyNames(fileText);
-            var info = new Info(server, assemblyNames);
+            var info = new Info(server, assemblyNames, supportsSymbolRedirect);
             federations.Add(info);
+        }
+
+        private static bool GetSupportsSymbolRedirect(string server)
+        {
+            try
+            {
+                string json = httpClient.GetStringAsync(
+                    GetServerUrl(server, "Federation.json")).GetAwaiter().GetResult();
+                return JsonSerializer.Deserialize<Capabilities>(json)?.SymbolRedirect == true;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
         }
 
         private HashSet<string> GetAssemblyNames(string assemblyList)
@@ -105,15 +146,18 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private string GetAssemblyUrl(string server)
         {
-            var url = server;
+            return GetServerUrl(server, "Assemblies.txt");
+        }
+
+        private static string GetServerUrl(string server, string relativePath)
+        {
+            string url = server;
             if (!url.EndsWith("/", StringComparison.Ordinal))
             {
                 url += "/";
             }
 
-            url += "Assemblies.txt";
-
-            return url;
+            return url + relativePath;
         }
 
         public int GetExternalAssemblyIndex(string assemblyName)
@@ -128,6 +172,16 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
 
             return -1;
+        }
+
+        public string GetExternalSymbolPath(int externalAssemblyIndex, string assemblyName, string symbolId)
+        {
+            if (federations[externalAssemblyIndex].SupportsSymbolRedirect)
+            {
+                return "api/symbolredirect?symbolId=" + symbolId;
+            }
+
+            return assemblyName + "/A.html#" + symbolId;
         }
 
         public IEnumerable<string> GetServers()

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -609,6 +609,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             return Federation.GetExternalAssemblyIndex(assemblyName);
         }
 
+        public string GetExternalSymbolPath(int externalAssemblyIndex, string assemblyName, string symbolId)
+        {
+            return Federation.GetExternalSymbolPath(externalAssemblyIndex, assemblyName, symbolId);
+        }
+
         private async Task<Solution> CreateSolutionAsync(string solutionFilePath, CancellationToken cancellationToken, ImmutableDictionary<string, string> properties = null, bool doNotIncludeReferencedProjects = false)
         {
             try

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/ClrOperatorCompatibilityTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/ClrOperatorCompatibilityTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.SourceBrowser.SourceIndexServer.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
+{
+    [TestClass]
+    public class ClrOperatorCompatibilityTests
+    {
+        [TestMethod]
+        public void EveryRoslynOperatorNameHasSearchInterpretations()
+        {
+            var operatorNames = typeof(WellKnownMemberNames)
+                .GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f =>
+                    f.FieldType == typeof(string) &&
+                    (f.Name.EndsWith("OperatorName", StringComparison.Ordinal) ||
+                    f.Name.EndsWith("ConversionName", StringComparison.Ordinal)))
+                .Select(f => (string)f.GetValue(null));
+
+            foreach (string operatorName in operatorNames)
+            {
+                AssertHasAlternateInterpretation(operatorName.Substring("op_".Length));
+            }
+        }
+
+        [TestMethod]
+        [DataRow("LogicalAnd", WellKnownMemberNames.LogicalAndOperatorName)]
+        [DataRow("LogicalOr", WellKnownMemberNames.LogicalOrOperatorName)]
+        [DataRow("UnsignedLeftShift", WellKnownMemberNames.UnsignedLeftShiftOperatorName)]
+        public void MetadataOnlyOperatorNamesResolveToClrName(string friendlyName, string clrName)
+        {
+            var query = new Query(friendlyName);
+
+            Assert.IsTrue(query.Interpretations.Any(i => i.CoreSearchTerm == clrName));
+        }
+
+        private static void AssertHasAlternateInterpretation(string operatorName)
+        {
+            var query = new Query(operatorName);
+
+            Assert.IsTrue(
+                query.Interpretations.Any(
+                    i => !i.CoreSearchTerm.Equals(operatorName, StringComparison.OrdinalIgnoreCase)),
+                operatorName);
+        }
+    }
+}

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/IndexUnitTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/IndexUnitTests.cs
@@ -133,6 +133,76 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
         }
 
         [TestMethod]
+        public void TestConversionOperatorSearch()
+        {
+            var symbols = new EntryList
+            {
+                {
+                    "Addition",
+                    "System.Decimal32.Addition"
+                },
+                {
+                    "explicit operator Decimal32",
+                    "System.Decimal32.explicit operator System.Decimal32(System.Decimal)"
+                },
+                {
+                    "operator +",
+                    "System.Decimal32.operator +(System.Decimal32, System.Decimal32)"
+                }
+            };
+
+            Test(
+                symbols,
+                "explicit operator",
+                "System.Decimal32.explicit operator System.Decimal32(System.Decimal)");
+            Test(
+                symbols,
+                "operator Decimal32",
+                "System.Decimal32.explicit operator System.Decimal32(System.Decimal)");
+            Test(
+                symbols,
+                "op_Explicit Decimal32",
+                "System.Decimal32.explicit operator System.Decimal32(System.Decimal)");
+            Test(
+                symbols,
+                "Explicit Decimal32",
+                "System.Decimal32.explicit operator System.Decimal32(System.Decimal)");
+            Test(
+                symbols,
+                "op_Addition",
+                "System.Decimal32.operator +(System.Decimal32, System.Decimal32)");
+            Test(
+                symbols,
+                "Addition",
+                "System.Decimal32.Addition",
+                "System.Decimal32.operator +(System.Decimal32, System.Decimal32)");
+        }
+
+        [TestMethod]
+        public void TestVisualBasicOperatorSearch()
+        {
+            var symbols = new EntryList
+            {
+                {
+                    "Narrowing Operator CType",
+                    "S.Narrowing Operator CType(S)"
+                },
+                {
+                    "Operator <>",
+                    "S.Operator <>(S, S)"
+                },
+                {
+                    "Operator =",
+                    "S.Operator =(S, S)"
+                }
+            };
+
+            Test(symbols, "op_Equality", "S.Operator =(S, S)");
+            Test(symbols, "op_Inequality", "S.Operator <>(S, S)");
+            Test(symbols, "op_Explicit", "S.Narrowing Operator CType(S)");
+        }
+
+        [TestMethod]
         public void TestVerbatimQuery_DoesNotUseCamelOrSubstringFallback()
         {
             Test(

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/QueryUnitTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/QueryUnitTests.cs
@@ -73,6 +73,187 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
             "Console System.Core");
         }
 
+        [TestMethod]
+        public void TypeAliasesMatchIndexedNames()
+        {
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "Size",
+                Description = "nint.Size",
+                Kind = SymbolKindText.Property
+            },
+            "IntPtr.Size",
+            "System.IntPtr.Size");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "nint",
+                Description = "nint",
+                Kind = SymbolKindText.Struct
+            },
+            "IntPtr",
+            "System.IntPtr");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "Size",
+                Description = "nuint.Size",
+                Kind = SymbolKindText.Property
+            },
+            "UIntPtr.Size",
+            "System.UIntPtr.Size");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "MaxValue",
+                Description = "System.Int32.MaxValue",
+                Kind = SymbolKindText.Field
+            },
+            "int.MaxValue");
+
+            NoMatch(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "MaxValue",
+                Description = "nint.MaxValue",
+                Kind = SymbolKindText.Property
+            },
+            "int.MaxValue");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "Size",
+                Description = "IntPtr.Size",
+                Kind = SymbolKindText.Property
+            },
+            "IntPtr.Size");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "Widget",
+                Description = "IntPtr.Nested.Widget",
+                Kind = SymbolKindText.Property
+            },
+            "Widget IntPtr.Nested");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "Member",
+                Description = "Long.Member",
+                Kind = SymbolKindText.Property
+            },
+            "Long.Member");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "Size",
+                Description = "IntPtr.Size",
+                Kind = SymbolKindText.Property
+            },
+            "IntPtr.get_Size");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "operator +",
+                Description = "IntPtr.operator +",
+                Kind = SymbolKindText.Method
+            },
+            "IntPtr.op_Addition");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "MaxValue",
+                Description = "System.Int64.MaxValue",
+                Kind = SymbolKindText.Field
+            },
+            "long.MaxValue");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = "Int32",
+                Description = "System.Int32",
+                Kind = SymbolKindText.Struct
+            },
+            "int");
+        }
+
+        [TestMethod]
+        [DataRow("bool", "Boolean")]
+        [DataRow("byte", "Byte")]
+        [DataRow("sbyte", "SByte")]
+        [DataRow("short", "Int16")]
+        [DataRow("ushort", "UInt16")]
+        [DataRow("int", "Int32")]
+        [DataRow("uint", "UInt32")]
+        [DataRow("long", "Int64")]
+        [DataRow("ulong", "UInt64")]
+        [DataRow("char", "Char")]
+        [DataRow("float", "Single")]
+        [DataRow("double", "Double")]
+        [DataRow("decimal", "Decimal")]
+        [DataRow("string", "String")]
+        [DataRow("object", "Object")]
+        [DataRow("void", "Void")]
+        public void KeywordAndClrTypeNamesFindSpecialTypes(string keyword, string clrName)
+        {
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = clrName,
+                Description = "System." + clrName,
+                Kind = SymbolKindText.Struct
+            },
+            keyword,
+            clrName,
+            "System." + clrName);
+        }
+
+        [TestMethod]
+        [DataRow("nint", "IntPtr")]
+        [DataRow("nuint", "UIntPtr")]
+        public void KeywordAndClrTypeNamesFindNativeIntegerTypes(string keyword, string clrName)
+        {
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "System.Private.CoreLib",
+                Name = keyword,
+                Description = keyword,
+                Kind = SymbolKindText.Struct
+            },
+            keyword,
+            clrName,
+            "System." + clrName);
+        }
+
+        [TestMethod]
+        [DataRow("int.MaxValue", "MaxValue", "Int32.MaxValue")]
+        [DataRow("IntPtr.Size", "Size", "nint.Size")]
+        [DataRow("System.IntPtr.Size", "Size", "nint.Size")]
+        public void DottedTypeAliasesUseSingleCoreInterpretation(
+            string queryText,
+            string coreSearchTerm,
+            string namespaceFilter)
+        {
+            var query = new Query(queryText);
+            var interpretations = query.Interpretations
+                .Where(i => i.CoreSearchTerm == coreSearchTerm)
+                .ToArray();
+
+            Assert.AreEqual(1, interpretations.Length);
+            Assert.AreEqual(namespaceFilter, interpretations[0].Namespace);
+        }
+
         private void Match(DeclaredSymbolInfo declaredSymbolInfo, params string[] queryStrings)
         {
             foreach (var queryString in queryStrings)

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/QueryUnitTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/QueryUnitTests.cs
@@ -127,11 +127,29 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
             Match(new DeclaredSymbolInfo
             {
                 AssemblyName = "Example",
+                Name = "MaxValue",
+                Description = "Example.Int32.MaxValue",
+                Kind = SymbolKindText.Field
+            },
+            "int.MaxValue");
+
+            Match(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
                 Name = "Size",
                 Description = "IntPtr.Size",
                 Kind = SymbolKindText.Property
             },
             "IntPtr.Size");
+
+            NoMatch(new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = "Size",
+                Description = "Example.IntPtr.Size",
+                Kind = SymbolKindText.Property
+            },
+            "System.IntPtr.Size");
 
             Match(new DeclaredSymbolInfo
             {
@@ -234,6 +252,17 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
             keyword,
             clrName,
             "System." + clrName);
+
+            var customType = new DeclaredSymbolInfo
+            {
+                AssemblyName = "Example",
+                Name = clrName,
+                Description = "Example." + clrName,
+                Kind = SymbolKindText.Struct
+            };
+
+            Match(customType, clrName);
+            NoMatch(customType, "System." + clrName);
         }
 
         [TestMethod]

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/SourceIndexServer.Tests.csproj
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/SourceIndexServer.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/SpecialTypeCompatibilityTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/SpecialTypeCompatibilityTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.SourceBrowser.SourceIndexServer.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
+{
+    [TestClass]
+    public class SpecialTypeCompatibilityTests
+    {
+        [TestMethod]
+        public void EveryPredefinedTypeKeywordHasASearchInterpretation()
+        {
+            var keywordKinds = SyntaxFacts.GetKeywordKinds()
+                .Concat(SyntaxFacts.GetContextualKeywordKinds())
+                .Where(SyntaxFacts.IsPredefinedType);
+
+            foreach (var keywordKind in keywordKinds)
+            {
+                string keyword = SyntaxFacts.GetText(keywordKind);
+                string dottedName = keyword + ".Member";
+                string normalizedName = Interpretation.NormalizeTypeAliases(dottedName);
+
+                if (keyword.Equals("nint", StringComparison.OrdinalIgnoreCase) ||
+                    keyword.Equals("nuint", StringComparison.OrdinalIgnoreCase))
+                {
+                    Assert.AreEqual(dottedName, normalizedName, keyword);
+                }
+                else
+                {
+                    Assert.AreNotEqual(dottedName, normalizedName, keyword);
+                }
+            }
+        }
+    }
+}

--- a/src/SourceBrowser/src/SourceIndexServer.Tests/SymbolsControllerTests.cs
+++ b/src/SourceBrowser/src/SourceIndexServer.Tests/SymbolsControllerTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SourceBrowser.SourceIndexServer;
+using Microsoft.SourceBrowser.SourceIndexServer.Controllers;
+using Microsoft.SourceBrowser.SourceIndexServer.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Index = Microsoft.SourceBrowser.SourceIndexServer.Models.Index;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Tests
+{
+    [TestClass]
+    public class SymbolsControllerTests
+    {
+        [TestMethod]
+        public void SymbolRedirectUsesIndexedImplementationAssembly()
+        {
+            const string symbolIdText = "8281103e6f23cb5c";
+            Assert.IsTrue(SymbolsController.TryParseHexStringToULong(symbolIdText, out ulong symbolId));
+            using var index = new Index();
+            index.assemblies.Add(new AssemblyInfo("System.Private.CoreLib;-1;0"));
+            index.symbols.Add(new IndexEntry(new DeclaredSymbolInfo
+            {
+                AssemblyNumber = 0,
+                ID = symbolId,
+                Name = "String"
+            }));
+            index.PopulateSymbolsById();
+
+            using var provider = new ServiceCollection()
+                .AddSingleton(index)
+                .BuildServiceProvider();
+            var controller = new SymbolsController(provider);
+
+            var result = controller.RedirectToSymbol(symbolIdText) as LocalRedirectResult;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(
+                "/System.Private.CoreLib/A.html#8281103e6f23cb5c",
+                result.Url);
+        }
+    }
+}

--- a/src/SourceBrowser/src/SourceIndexServer/Controllers/SymbolsController.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Controllers/SymbolsController.cs
@@ -55,25 +55,10 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Controllers
         {
             try
             {
-                if (!TryGetSymbolId(symbolId, out ulong id))
+                if (!TryGetSymbolUrl(symbolId, out string url))
                 {
                     return NotFound();
                 }
-
-                var index = _provider.GetRequiredService<Index>();
-                if (!index.symbolsById.TryGetValue(id, out int position))
-                {
-                    return NotFound();
-                }
-
-                if (position < 0 || position >= index.symbols.Count)
-                {
-                    return NotFound();
-                }
-
-                var symbol = index.symbols[position];
-                var info = symbol.GetDeclaredSymbolInfo(index.huffman, index.assemblies, index.projects);
-                var url = info.GetUrl();
 
                 return Content(url, "text/plain", Encoding.UTF8);
             }
@@ -82,6 +67,47 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Controllers
                 var text = Markup.Note(ex.ToString());
                 return NotFound(text);
             }
+        }
+
+        [HttpGet("/api/symbolredirect")]
+        public IActionResult RedirectToSymbol(string symbolId)
+        {
+            try
+            {
+                if (!TryGetSymbolUrl(symbolId, out string url))
+                {
+                    return NotFound();
+                }
+
+                return LocalRedirect(url);
+            }
+            catch (Exception ex)
+            {
+                var text = Markup.Note(ex.ToString());
+                return NotFound(text);
+            }
+        }
+
+        private bool TryGetSymbolUrl(string symbolId, out string url)
+        {
+            url = null;
+            if (!TryGetSymbolId(symbolId, out ulong id))
+            {
+                return false;
+            }
+
+            var index = _provider.GetRequiredService<Index>();
+            if (!index.symbolsById.TryGetValue(id, out int position) ||
+                position < 0 ||
+                position >= index.symbols.Count)
+            {
+                return false;
+            }
+
+            var symbol = index.symbols[position];
+            var info = symbol.GetDeclaredSymbolInfo(index.huffman, index.assemblies, index.projects);
+            url = info.GetUrl();
+            return true;
         }
 
         private bool TryGetSymbolId(string text, out ulong id)

--- a/src/SourceBrowser/src/SourceIndexServer/Models/Query.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/Query.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +9,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
     public class Query
     {
+        private static readonly FrozenDictionary<string, string[]> clrOperatorNames = CreateClrOperatorNames();
         private readonly StringBuilder diagnostics = new StringBuilder();
 
         public readonly List<string> Paths = new List<string>();
@@ -164,6 +166,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 this.Interpretations.Add(interpretation);
                 AddPossibleInterpretationWithoutClrPrefix(interpretation);
                 AddPossibleTypeAliasInterpretation(interpretation);
+                AddPossibleClrOperatorInterpretation(interpretation);
             }
 
             foreach (var dottedName in this.DotSeparatedNames)
@@ -207,6 +210,107 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 this.Interpretations.Add(interpretation);
                 AddPossibleInterpretationWithoutClrPrefix(interpretation);
                 AddPossibleTypeAliasInterpretation(interpretation);
+                AddPossibleClrOperatorInterpretation(interpretation);
+            }
+        }
+
+        private static FrozenDictionary<string, string[]> CreateClrOperatorNames()
+        {
+            var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+            AddClrOperatorName(result, "UnaryPlus", "operator +");
+            AddClrOperatorName(result, "UnaryNegation", "operator -");
+            AddClrOperatorName(result, "LogicalNot", "operator !", "operator Not");
+            AddClrOperatorName(result, "OnesComplement", "operator ~", "operator Not");
+            AddClrOperatorName(result, "Increment", "operator ++");
+            AddClrOperatorName(result, "Decrement", "operator --");
+            AddClrOperatorName(result, "True", "operator true", "operator IsTrue");
+            AddClrOperatorName(result, "False", "operator false", "operator IsFalse");
+            AddClrOperatorName(result, "Addition", "operator +");
+            AddClrOperatorName(result, "Subtraction", "operator -");
+            AddClrOperatorName(result, "Multiply", "operator *");
+            AddClrOperatorName(result, "Division", "operator /");
+            AddClrOperatorName(result, "Modulus", "operator %", "operator Mod");
+            AddClrOperatorName(result, "BitwiseAnd", "operator &", "operator And");
+            AddClrOperatorName(result, "BitwiseOr", "operator |", "operator Or");
+            AddClrOperatorName(result, "ExclusiveOr", "operator ^", "operator Xor");
+            AddClrOperatorName(result, "LeftShift", "operator <<");
+            AddClrOperatorName(result, "UnsignedLeftShift", "op_UnsignedLeftShift");
+            AddClrOperatorName(result, "RightShift", "operator >>");
+            AddClrOperatorName(result, "UnsignedRightShift", "operator >>>");
+            AddClrOperatorName(result, "LogicalAnd", "op_LogicalAnd");
+            AddClrOperatorName(result, "LogicalOr", "op_LogicalOr");
+            AddClrOperatorName(result, "Equality", "operator ==", "operator =");
+            AddClrOperatorName(result, "Inequality", "operator !=", "operator <>");
+            AddClrOperatorName(result, "LessThan", "operator <");
+            AddClrOperatorName(result, "GreaterThan", "operator >");
+            AddClrOperatorName(result, "LessThanOrEqual", "operator <=");
+            AddClrOperatorName(result, "GreaterThanOrEqual", "operator >=");
+            AddClrOperatorName(result, "Implicit", "implicit operator", "Widening operator CType");
+            AddClrOperatorName(result, "Explicit", "explicit operator", "Narrowing operator CType");
+            AddClrOperatorName(result, "CheckedUnaryNegation", "operator checked -");
+            AddClrOperatorName(result, "CheckedIncrement", "operator checked ++");
+            AddClrOperatorName(result, "CheckedDecrement", "operator checked --");
+            AddClrOperatorName(result, "CheckedAddition", "operator checked +");
+            AddClrOperatorName(result, "CheckedSubtraction", "operator checked -");
+            AddClrOperatorName(result, "CheckedMultiply", "operator checked *");
+            AddClrOperatorName(result, "CheckedDivision", "operator checked /");
+            AddClrOperatorName(result, "CheckedExplicit", "explicit operator checked");
+            AddClrOperatorName(result, "Concatenate", "operator &");
+            AddClrOperatorName(result, "Exponent", "operator ^");
+            AddClrOperatorName(result, "IntegerDivision", "operator \\");
+            AddClrOperatorName(result, "Like", "operator Like");
+            AddClrOperatorName(result, "AdditionAssignment", "operator +=");
+            AddClrOperatorName(result, "SubtractionAssignment", "operator -=");
+            AddClrOperatorName(result, "MultiplicationAssignment", "operator *=");
+            AddClrOperatorName(result, "DivisionAssignment", "operator /=");
+            AddClrOperatorName(result, "ModulusAssignment", "operator %=");
+            AddClrOperatorName(result, "BitwiseAndAssignment", "operator &=");
+            AddClrOperatorName(result, "BitwiseOrAssignment", "operator |=");
+            AddClrOperatorName(result, "ExclusiveOrAssignment", "operator ^=");
+            AddClrOperatorName(result, "LeftShiftAssignment", "operator <<=");
+            AddClrOperatorName(result, "RightShiftAssignment", "operator >>=");
+            AddClrOperatorName(result, "UnsignedRightShiftAssignment", "operator >>>=");
+            AddClrOperatorName(result, "IncrementAssignment", "operator ++");
+            AddClrOperatorName(result, "DecrementAssignment", "operator --");
+            AddClrOperatorName(result, "CheckedAdditionAssignment", "operator checked +=");
+            AddClrOperatorName(result, "CheckedSubtractionAssignment", "operator checked -=");
+            AddClrOperatorName(result, "CheckedMultiplicationAssignment", "operator checked *=");
+            AddClrOperatorName(result, "CheckedDivisionAssignment", "operator checked /=");
+            AddClrOperatorName(result, "CheckedIncrementAssignment", "operator checked ++");
+            AddClrOperatorName(result, "CheckedDecrementAssignment", "operator checked --");
+
+            return result.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static void AddClrOperatorName(
+            Dictionary<string, string[]> names,
+            string clrName,
+            params string[] sourceNames)
+        {
+            names.Add(clrName, sourceNames);
+            string metadataName = "op_" + clrName;
+            if (!sourceNames.Contains(metadataName, StringComparer.OrdinalIgnoreCase))
+            {
+                names.Add(metadataName, sourceNames);
+            }
+        }
+
+        private void AddPossibleClrOperatorInterpretation(Interpretation interpretation)
+        {
+            if (!clrOperatorNames.TryGetValue(
+                interpretation.CoreSearchTerm,
+                out string[] sourceNames))
+            {
+                return;
+            }
+
+            foreach (string sourceName in sourceNames)
+            {
+                var clone = interpretation.Clone();
+                clone.CoreSearchTerm = sourceName;
+                ReplaceNamespaceSuffix(clone, interpretation.CoreSearchTerm, sourceName);
+                this.Interpretations.Add(clone);
             }
         }
 

--- a/src/SourceBrowser/src/SourceIndexServer/Models/Query.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/Query.cs
@@ -158,11 +158,12 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 
                 foreach (var dottedName in this.DotSeparatedNames)
                 {
-                    interpretation.FilterDotSeparatedNames.Add(dottedName.StripQuotes());
+                    AddDottedNameFilter(interpretation, dottedName.StripQuotes());
                 }
 
                 this.Interpretations.Add(interpretation);
                 AddPossibleInterpretationWithoutClrPrefix(interpretation);
+                AddPossibleTypeAliasInterpretation(interpretation);
             }
 
             foreach (var dottedName in this.DotSeparatedNames)
@@ -185,7 +186,14 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 var interpretation = new Interpretation();
                 interpretation.CoreSearchTerm = lastPart;
                 interpretation.IsVerbatim = isQuoted;
-                interpretation.Namespace = dottedNameText;
+                interpretation.Namespace = Interpretation.NormalizeTypeAliases(
+                    dottedNameText,
+                    out bool preserveOriginalNamespace);
+                if (preserveOriginalNamespace)
+                {
+                    interpretation.AlternateNamespace = dottedNameText;
+                }
+
                 foreach (var name in this.Names)
                 {
                     interpretation.FilterNames.Add(name.StripQuotes());
@@ -193,11 +201,37 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 
                 foreach (var otherDottedName in this.DotSeparatedNames.Where(i => i != dottedNameText))
                 {
-                    interpretation.FilterDotSeparatedNames.Add(otherDottedName.StripQuotes());
+                    AddDottedNameFilter(interpretation, otherDottedName.StripQuotes());
                 }
 
                 this.Interpretations.Add(interpretation);
                 AddPossibleInterpretationWithoutClrPrefix(interpretation);
+                AddPossibleTypeAliasInterpretation(interpretation);
+            }
+        }
+
+        private void AddPossibleTypeAliasInterpretation(Interpretation interpretation)
+        {
+            var normalizedSearchTerm = Interpretation.NormalizeTypeAliases(interpretation.CoreSearchTerm);
+            if (ReferenceEquals(normalizedSearchTerm, interpretation.CoreSearchTerm))
+            {
+                return;
+            }
+
+            var clone = interpretation.Clone();
+            clone.CoreSearchTerm = normalizedSearchTerm;
+            this.Interpretations.Add(clone);
+        }
+
+        private static void AddDottedNameFilter(Interpretation interpretation, string dottedName)
+        {
+            string normalizedName = Interpretation.NormalizeTypeAliases(
+                dottedName,
+                out bool preserveOriginal);
+            interpretation.FilterDotSeparatedNames.Add(normalizedName);
+            if (preserveOriginal)
+            {
+                interpretation.FilterDotSeparatedNames.Add(dottedName);
             }
         }
 
@@ -232,16 +266,43 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
                 {
                     var clone = interpretation.Clone();
                     clone.CoreSearchTerm = clone.CoreSearchTerm.Substring(prefix.Length);
-                    if (clone.Namespace != null)
-                    {
-                        clone.Namespace = clone.Namespace.Replace(prefix, "");
-                    }
+                    ReplaceNamespaceSuffix(
+                        clone,
+                        interpretation.CoreSearchTerm,
+                        clone.CoreSearchTerm);
 
                     return clone;
                 }
             }
 
             return null;
+        }
+
+        private static void ReplaceNamespaceSuffix(
+            Interpretation interpretation,
+            string oldSuffix,
+            string newSuffix)
+        {
+            interpretation.Namespace = ReplaceSuffix(
+                interpretation.Namespace,
+                oldSuffix,
+                newSuffix);
+            interpretation.AlternateNamespace = ReplaceSuffix(
+                interpretation.AlternateNamespace,
+                oldSuffix,
+                newSuffix);
+        }
+
+        private static string ReplaceSuffix(string text, string oldSuffix, string newSuffix)
+        {
+            if (text is null)
+            {
+                return null;
+            }
+
+            return string.Concat(
+                text.AsSpan(0, text.Length - oldSuffix.Length),
+                newSuffix.AsSpan());
         }
 
         public static string StripQuotes(string text, out bool isQuoted)

--- a/src/SourceBrowser/src/SourceIndexServer/Models/QueryInterpretation.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/QueryInterpretation.cs
@@ -143,8 +143,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
             {
                 aliasLength = text.Length;
             }
-            else if (aliasLength == "System".Length &&
-                text.AsSpan(0, aliasLength).Equals("System", StringComparison.OrdinalIgnoreCase))
+            else if (text.AsSpan(0, aliasLength).Equals("System", StringComparison.OrdinalIgnoreCase))
             {
                 int memberSeparator = text.IndexOf('.', aliasLength + 1);
                 aliasLength = memberSeparator < 0 ? text.Length : memberSeparator;

--- a/src/SourceBrowser/src/SourceIndexServer/Models/QueryInterpretation.cs
+++ b/src/SourceBrowser/src/SourceIndexServer/Models/QueryInterpretation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,9 +7,35 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
 {
     public class Interpretation
     {
+        private static readonly FrozenDictionary<string, string> typeAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["bool"] = "Boolean",
+                ["byte"] = "Byte",
+                ["sbyte"] = "SByte",
+                ["short"] = "Int16",
+                ["ushort"] = "UInt16",
+                ["int"] = "Int32",
+                ["uint"] = "UInt32",
+                ["long"] = "Int64",
+                ["ulong"] = "UInt64",
+                ["char"] = "Char",
+                ["float"] = "Single",
+                ["double"] = "Double",
+                ["decimal"] = "Decimal",
+                ["string"] = "String",
+                ["object"] = "Object",
+                ["void"] = "Void",
+                ["IntPtr"] = "nint",
+                ["UIntPtr"] = "nuint",
+                ["System.IntPtr"] = "nint",
+                ["System.UIntPtr"] = "nuint",
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
         public string CoreSearchTerm { get; set; }
         public bool IsVerbatim { get; set; }
         public string Namespace { get; set; }
+        public string AlternateNamespace { get; set; }
         public List<string> FilterNames { get; private set; }
         public List<string> FilterDotSeparatedNames { get; private set; }
 
@@ -24,6 +51,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
             newInterpretation.CoreSearchTerm = CoreSearchTerm;
             newInterpretation.IsVerbatim = IsVerbatim;
             newInterpretation.Namespace = Namespace;
+            newInterpretation.AlternateNamespace = AlternateNamespace;
             newInterpretation.FilterNames = new List<string>(FilterNames);
             newInterpretation.FilterDotSeparatedNames = new List<string>(FilterDotSeparatedNames);
             return newInterpretation;
@@ -64,7 +92,10 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
             }
             else
             {
-                return FilterAssemblies(symbol) && FilterNamespace(symbol, this.Namespace);
+                return FilterAssemblies(symbol) &&
+                    (FilterNamespace(symbol, this.Namespace) ||
+                    (this.AlternateNamespace is not null &&
+                    FilterNamespace(symbol, this.AlternateNamespace)));
             }
         }
 
@@ -72,19 +103,62 @@ namespace Microsoft.SourceBrowser.SourceIndexServer.Models
         {
             var description = symbol.Description;
             int openParen = description.IndexOf('(');
-            if (openParen > -1)
+            int descriptionLength = openParen < 0 ? description.Length : openParen;
+            ReadOnlySpan<char> remainingDescription = description.AsSpan(0, descriptionLength);
+
+            while (true)
             {
-                // if the description contains (, we should only search before it, to not accidentally
-                // match any of the parameters that may follow afterwards
-                description = description.Substring(0, openParen);
+                int matchIndex = remainingDescription.IndexOf(
+                    namespacePrefix,
+                    StringComparison.OrdinalIgnoreCase);
+                if (matchIndex < 0)
+                {
+                    return false;
+                }
+
+                if (matchIndex == 0 || !IsIdentifierCharacter(remainingDescription[matchIndex - 1]))
+                {
+                    return true;
+                }
+
+                remainingDescription = remainingDescription.Slice(matchIndex + 1);
+            }
+        }
+
+        private static bool IsIdentifierCharacter(char character)
+        {
+            return character == '_' || char.IsLetterOrDigit(character);
+        }
+
+        internal static string NormalizeTypeAliases(string text)
+        {
+            return NormalizeTypeAliases(text, out _);
+        }
+
+        internal static string NormalizeTypeAliases(string text, out bool preserveOriginal)
+        {
+            preserveOriginal = false;
+            int aliasLength = text.IndexOf('.');
+            if (aliasLength < 0)
+            {
+                aliasLength = text.Length;
+            }
+            else if (aliasLength == "System".Length &&
+                text.AsSpan(0, aliasLength).Equals("System", StringComparison.OrdinalIgnoreCase))
+            {
+                int memberSeparator = text.IndexOf('.', aliasLength + 1);
+                aliasLength = memberSeparator < 0 ? text.Length : memberSeparator;
             }
 
-            if (description.IndexOf(namespacePrefix, StringComparison.OrdinalIgnoreCase) != -1)
+            if (typeAliases
+                .GetAlternateLookup<ReadOnlySpan<char>>()
+                .TryGetValue(text.AsSpan(0, aliasLength), out string indexedName))
             {
-                return true;
+                preserveOriginal = true;
+                return string.Concat(indexedName.AsSpan(), text.AsSpan(aliasLength));
             }
 
-            return false;
+            return text;
         }
 
         private bool FilterAssemblies(DeclaredSymbolInfo symbol)

--- a/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
+++ b/src/SourceBrowser/src/SourceIndexServer/SourceIndexServer.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SourceIndexServer.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/Federation.json
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/Federation.json
@@ -1,0 +1,1 @@
+{"symbolRedirect":true}

--- a/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceBrowser/src/SourceIndexServer/wwwroot/scripts.js
@@ -1,5 +1,6 @@
 var currentSelection = null;
 var currentResult = null;
+var searchTimerID = -1;
 var useSolutionExplorer = /*USE_SOLUTION_EXPLORER*/true/*USE_SOLUTION_EXPLORER*/;
 // Off by default -- most sites generated with this tool aren't Microsoft's own code, so the
 // .NET/Microsoft logo marks in the header are opt-in via the HtmlGenerator /showBranding flag
@@ -283,7 +284,6 @@ function initPaneResizer() {
 
 function onHeaderLoad() {
     ensureSearchBox();
-    searchTimerID = -1;
     lastQuery = null;
     lastSearchString = searchBox.value;
 
@@ -1004,12 +1004,29 @@ function onSearchChange() {
         if (searchTimerID == -1) {
             searchTimerID = setTimeout(runSearch, 200);
         }
-    } else if (searchBox.value.length === 0 && useSolutionExplorer) {
+        return;
+    }
+
+    cancelPendingSearch();
+    if (searchBox.value.length === 0 && useSolutionExplorer) {
         // Nothing to search for -- go back to the primary Solution Explorer view (the same one
         // shown on first load) instead of leaving an empty/prompt-only results pane behind.
         returnToSolutionExplorer();
     } else {
         loadSearchResults("<div class='note'>Enter at least 3 characters.</div>");
+    }
+}
+
+function cancelPendingSearch() {
+    if (searchTimerID != -1) {
+        clearTimeout(searchTimerID);
+        searchTimerID = -1;
+    }
+
+    var activeSearch = top.lastQuery;
+    top.lastQuery = null;
+    if (typeof activeSearch === "object" && activeSearch !== null) {
+        activeSearch.abort();
     }
 }
 
@@ -1027,12 +1044,7 @@ function returnToSolutionExplorer() {
 
 function runSearch() {
     ensureSearchBox();
-    searchTimerID = -1;
-    if (typeof lastQuery === "object" && lastQuery !== null) {
-        lastQuery.abort();
-        lastQuery = null;
-    }
-
+    cancelPendingSearch();
     setPageTitle(searchBox.value);
 
     var query = searchBox.value;
@@ -1041,7 +1053,7 @@ function runSearch() {
         query = "repo:" + selectedRepo + " " + query;
     }
 
-    lastQuery = getUrl("api/symbols/?symbol=" + encodeURIComponent(query), loadSearchResults);
+    top.lastQuery = getUrl("api/symbols/?symbol=" + encodeURIComponent(query), loadSearchResults);
 }
 
 function getUrl(url, callback) {
@@ -1055,11 +1067,20 @@ function getUrl(url, callback) {
             return response.ok ? response.text() : "";
         })
         .then(function (data) {
+            if (top.lastQuery !== controller) {
+                return;
+            }
+
+            top.lastQuery = null;
             if (typeof data === "string" && data.length > 0) {
                 callback(data);
             }
         })
         .catch(function () {
+            if (top.lastQuery === controller) {
+                top.lastQuery = null;
+            }
+
             // Ignore aborted or failed requests; the next keystroke reissues the search.
         });
     return controller;


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with Copilot.

Support searches using C# keywords, CLR type names, and qualified aliases, including `nint`/`IntPtr`, without repeating work per indexed candidate.

----------

Index C# and Visual Basic operator declarations and resolve both source spellings and CLR metadata names such as `op_Addition`.

----------

Keep search request ownership in the shared frame so stale responses cannot override repo-filtered results.