### PR TITLE
Fix superfluous `src` segment in github links

### DIFF
--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -22,7 +22,8 @@
     </Repository>
 
     <RepositoryV2>
-      <LocalPath>$(RepositoryPath)%(Identity)/</LocalPath>
+      <!-- Standalone stage 1 bundles place repository-relative files under src/. -->
+      <LocalPath>$(RepositoryPath)%(Identity)/src/</LocalPath>
       <ExtractPath>$(RepositoryPath)%(Identity)/</ExtractPath>
     </RepositoryV2>
   </ItemDefinitionGroup>

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -22,6 +22,7 @@
     <RepositoryV2 Include="dotnet">
       <RepoName>dotnet-dotnet</RepoName>
       <Url>https://github.com/dotnet/dotnet</Url>
+      <LocalPath>$(RepositoryPath)dotnet/</LocalPath>
       <!-- Emit a per-subfolder repo filter tag for each entry in the VMR's source manifest,
            so search can be scoped to the originating repo (dotnet/runtime, ...). Source links
            are unaffected: files still point at dotnet/dotnet. -->

--- a/src/index/repositories.props
+++ b/src/index/repositories.props
@@ -43,8 +43,8 @@
       <Url>https://github.com/dotnet/wcf</Url>
     </RepositoryV2>
     <RepositoryV2 Include="aspire">
-      <RepoName>dotnet-aspire</RepoName>
-      <Url>https://github.com/dotnet/aspire</Url>
+      <RepoName>microsoft-aspire</RepoName>
+      <Url>https://github.com/microsoft/aspire</Url>
     </RepositoryV2>
     <RepositoryV2 Include="extensions">
       <RepoName>dotnet-extensions</RepoName>


### PR DESCRIPTION
As you can see for example in https://source.dot.net/#AppHost1/Program.cs, the "Web Access" link leads to a non-existent URL: https://github.com/dotnet/aspire/tree/d4a981745dc8b1fdca870b77601ba6e47b1a509d/src/playground/SqlServerScript/AppHost1/Program.cs due to a superfluous `src/` segment in the path.