### PR TITLE
Avoid full paths in page titles

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private async Task GenerateHtmlAsync(StreamWriter writer)
         {
-            var title = Document.Name;
+            var title = Path.GetFileName(Document.Name);
             var lineCount = Text.Lines.Count;
 
             // if the document is very long, pregenerate line numbers statically


### PR DESCRIPTION
Complog-based repos (currently dotnet/extensions) have full paths in page titles (`D:\a\1\_work\...`), unlike BinLogToSln-based repos; this PR should fix that.