### PR TITLE
Fix complog repo folder mapping

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator.Tests/SolutionExplorerGroupingTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/SolutionExplorerGroupingTests.cs
@@ -144,6 +144,20 @@ namespace HtmlGenerator.Tests
         }
 
         [TestMethod]
+        public void Bundle_and_source_roots_can_map_to_the_same_repo()
+        {
+            var mappings = new Dictionary<string, string>
+            {
+                [@"C:\bundle"] = "dotnet/extensions",
+                [@"C:\bundle\src"] = "dotnet/extensions",
+            };
+
+            Program.GetRepoName(@"C:\bundle\logs\extensions.complog", mappings).ShouldBe("dotnet/extensions");
+            Program.ResolveRepoChain(@"C:\bundle\src\Foo\Foo.csproj", mappings, "")
+                .ShouldBe(new[] { "dotnet/extensions" });
+        }
+
+        [TestMethod]
         public void Nested_repo_chain_groups_a_sub_repo_under_its_parent_repo_folder()
         {
             var root = new Folder<ProjectSkeleton>();

--- a/src/index/index.proj
+++ b/src/index/index.proj
@@ -247,6 +247,9 @@
       <SourceIndexCmd>$(SourceIndexCmd) /in:"$(OutDir)index.list"</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepository -> ' /repo:"%(LocalPath)"="%(RepoDisplayName)"="%(ServerPath)"', '')</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepositoryV2 -> ' /repo:"%(LocalPath)"="%(RepoDisplayName)"="%(ServerPath)"', '')</SourceIndexCmd>
+      <!-- A standalone bundle's source-link root is src/, but its .complog inputs live elsewhere
+           under ExtractPath. Tag the entire bundle independently so those projects stay grouped. -->
+      <SourceIndexCmd>$(SourceIndexCmd)@(ClonedRepositoryV2 -> ' /repoPath:"%(ExtractPath)"="%(RepoDisplayName)"', '')</SourceIndexCmd>
       <SourceIndexCmd>$(SourceIndexCmd)@(SubRepoTag -> ' /repoPath:"%(Identity)"="%(RepoDisplayName)"', '')</SourceIndexCmd>
     </PropertyGroup>
     <Exec Command="$(SourceIndexCmd)" LogStandardErrorAsError="false"/>


### PR DESCRIPTION
Follow up on https://github.com/dotnet/source-indexer/pull/295. As you can see in the current deployment, dotnet/extensions is incorrectly outside any folder. (I think I've seen this locally during validation but didn't realize it as I was trying on a single repo only. And there is no staging validation on PRs as there used to be...)