### PR TITLE
Use PortablePdb with MetadataOnly emit

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogTypeForwardTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogTypeForwardTests.cs
@@ -17,7 +17,9 @@ namespace HtmlGenerator.Tests;
 public sealed class CompilerLogTypeForwardTests
 {
     [TestMethod]
-    public void Metadata_emit_omits_pdb_only_compiler_log_data()
+    [DataRow(DebugInformationFormat.PortablePdb)]
+    [DataRow(DebugInformationFormat.Embedded)]
+    public void Metadata_emit_omits_pdb_only_compiler_log_data(DebugInformationFormat debugInformationFormat)
     {
         var sourceText = SourceText.From("public class C { }", Encoding.UTF8);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: "Embedded.cs");
@@ -39,7 +41,7 @@ public sealed class CompilerLogTypeForwardTests
         var result = Program.EmitMetadataForTypeForwards(
             compilation,
             emitData,
-            new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
+            new EmitOptions(debugInformationFormat: debugInformationFormat));
         using var assemblyStream = result.AssemblyStream;
         using var pdbStream = result.PdbStream;
 

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -411,7 +411,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 EmitFlags.MetadataOnly,
                 win32ResourceStream: emitData.Win32ResourceStream,
                 manifestResources: emitData.Resources,
-                emitOptions: emitOptions);
+                // PortablePdb needed due to https://github.com/dotnet/roslyn/issues/78721.
+                emitOptions: emitOptions.WithDebugInformationFormat(DebugInformationFormat.PortablePdb));
         }
 
         private static async Task IndexSolutionsAsync(


### PR DESCRIPTION
Fixes the crash seen in https://dev.azure.com/dnceng/internal/_build/results?buildId=3059025&view=results.
Validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059096&view=results