### PR TITLE
Fix more complog-related issues

### DIFF
--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
@@ -52,5 +52,36 @@ namespace HtmlGenerator.Tests
             normalized.Projects.Select(p => p.AssemblyName)
                 .ShouldBe(new[] { "A", "B" }, ignoreOrder: true);
         }
+
+        [TestMethod]
+        public void Implementation_compilation_precedes_reference_assembly_with_the_same_name()
+        {
+            var referenceAssembly = CreateProjectInfo("A.dll", documentCount: 1);
+            var unrelated = CreateProjectInfo("B.dll", documentCount: 1);
+            var implementation = CreateProjectInfo("A.dll", documentCount: 10);
+            var original = SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Default,
+                projects: new[] { referenceAssembly, unrelated, implementation });
+
+            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(original);
+
+            normalized.Projects.Select(p => p.Id)
+                .ShouldBe(new[] { implementation.Id, unrelated.Id, referenceAssembly.Id });
+        }
+
+        private static ProjectInfo CreateProjectInfo(string assemblyName, int documentCount)
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documents = Enumerable.Range(0, documentCount)
+                .Select(i => DocumentInfo.Create(DocumentId.CreateNewId(projectId), $"{i}.cs"));
+            return ProjectInfo.Create(
+                projectId,
+                VersionStamp.Default,
+                name: assemblyName,
+                assemblyName: assemblyName,
+                language: LanguageNames.CSharp,
+                documents: documents);
+        }
     }
 }

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.SourceBrowser.HtmlGenerator;
@@ -68,6 +69,69 @@ namespace HtmlGenerator.Tests
 
             normalized.Projects.Select(p => p.Id)
                 .ShouldBe(new[] { implementation.Id, unrelated.Id, referenceAssembly.Id });
+        }
+
+        [TestMethod]
+        public void Compiler_log_document_folders_match_BinLogToSln_link_behavior()
+        {
+            const string repositoryRoot = @"D:\a\_work\1\s";
+            const string projectDirectory = repositoryRoot + @"\src\runtime\src\coreclr\System.Private.CoreLib";
+            var projectId = ProjectId.CreateNewId();
+            var localDocument = DocumentInfo.Create(
+                DocumentId.CreateNewId(projectId),
+                "Local.cs",
+                filePath: projectDirectory + @"\Internal\Local.cs");
+            var linkedDocument = DocumentInfo.Create(
+                DocumentId.CreateNewId(projectId),
+                "String.cs",
+                filePath: repositoryRoot + @"\src\runtime\src\libraries\System.Private.CoreLib\src\System\String.cs");
+            var project = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Default,
+                name: "System.Private.CoreLib",
+                assemblyName: "System.Private.CoreLib.dll",
+                language: LanguageNames.CSharp,
+                filePath: projectDirectory + @"\System.Private.CoreLib.csproj",
+                documents: new[] { localDocument, linkedDocument });
+            var solution = SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Default,
+                projects: new[] { project });
+            var repoPathMappings = new System.Collections.Generic.Dictionary<string, string>
+            {
+                [repositoryRoot] = "dotnet/dotnet",
+                [repositoryRoot + @"\src\runtime"] = "dotnet/runtime",
+            };
+
+            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(solution, repoPathMappings);
+            var documents = normalized.Projects.Single().Documents.ToDictionary(d => d.Name);
+
+            documents["Local.cs"].Folders.ShouldBe(new[] { "Internal" });
+            documents["String.cs"].Folders.ShouldBe(
+                new[] { "src", "runtime", "src", "libraries", "System.Private.CoreLib", "src", "System" });
+
+            using var workspace = new AdhocWorkspace();
+            workspace.AddSolution(normalized);
+            var stringDocument = workspace.CurrentSolution.Projects.Single().Documents.Single(d => d.Name == "String.cs");
+            Paths.GetRelativeFilePathInProject(stringDocument, project.FilePath).ShouldBe(
+                @"src\runtime\src\libraries\System.Private.CoreLib\src\System\String.cs");
+        }
+
+        [TestMethod]
+        public void Existing_compiler_log_document_folders_are_preserved()
+        {
+            var document = DocumentInfo.Create(
+                DocumentId.CreateNewId(ProjectId.CreateNewId()),
+                "Linked.cs",
+                folders: new[] { "Existing", "Link" },
+                filePath: @"D:\repo\src\Linked.cs");
+
+            var normalized = SolutionGenerator.AddCompilerLogDocumentFolders(
+                document,
+                @"D:\repo\project",
+                @"D:\repo");
+
+            normalized.ShouldBeSameAs(document);
         }
 
         private static ProjectInfo CreateProjectInfo(string assemblyName, int documentCount)

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogAssemblyNameTests.cs
@@ -97,13 +97,9 @@ namespace HtmlGenerator.Tests
                 SolutionId.CreateNewId(),
                 VersionStamp.Default,
                 projects: new[] { project });
-            var repoPathMappings = new System.Collections.Generic.Dictionary<string, string>
-            {
-                [repositoryRoot] = "dotnet/dotnet",
-                [repositoryRoot + @"\src\runtime"] = "dotnet/runtime",
-            };
-
-            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(solution, repoPathMappings);
+            var normalized = SolutionGenerator.NormalizeCompilerLogAssemblyNames(
+                solution,
+                compilerLogRepositoryRoots: new[] { repositoryRoot });
             var documents = normalized.Projects.Single().Documents.ToDictionary(d => d.Name);
 
             documents["Local.cs"].Folders.ShouldBe(new[] { "Internal" });

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogWebAccessTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogWebAccessTests.cs
@@ -137,4 +137,34 @@ public sealed class CompilerLogWebAccessTests
 
         result.ShouldBeSameAs(serverPathMappings);
     }
+
+    [TestMethod]
+    public void Vmr_subrepo_paths_are_aliased_under_the_original_compiler_root()
+    {
+        var repoPathMappings = new Dictionary<string, string>
+        {
+            [@"C:\index\dotnet\"] = "dotnet/dotnet",
+            [@"C:\index\dotnet\src\runtime"] = "dotnet/runtime",
+            [@"C:\index\dotnet\src\sdk"] = "dotnet/sdk",
+        };
+
+        var result = SolutionGenerator.AddCompilerLogRepoPathMappings(
+            repoPathMappings,
+            @"C:\index\dotnet\runtime.complog",
+            new Dictionary<string, string>
+            {
+                [@"D:\a\_work\1\s"] = @"/_/",
+            });
+
+        Program.ResolveRepoChain(
+                @"D:\a\_work\1\s\src\runtime\src\libraries\System.Private.CoreLib\System.Private.CoreLib.csproj",
+                result,
+                "dotnet/dotnet")
+            .ShouldBe(new[] { "dotnet/dotnet", "dotnet/runtime" });
+        Program.ResolveRepoName(
+                @"D:\a\_work\1\s\src\sdk\src\Cli\dotnet.csproj",
+                result,
+                "dotnet/dotnet")
+            .ShouldBe("dotnet/sdk");
+    }
 }

--- a/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogWebAccessTests.cs
+++ b/src/SourceBrowser/src/HtmlGenerator.Tests/CompilerLogWebAccessTests.cs
@@ -150,7 +150,7 @@ public sealed class CompilerLogWebAccessTests
 
         var result = SolutionGenerator.AddCompilerLogRepoPathMappings(
             repoPathMappings,
-            @"C:\index\dotnet\runtime.complog",
+            @"C:\index\dotnet\logs\runtime.complog",
             new Dictionary<string, string>
             {
                 [@"D:\a\_work\1\s"] = @"/_/",

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -87,6 +87,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         // so it must not be disposed until Pass1 generation has finished reading every document.
         private SolutionReader compilerLogReader;
 
+        private readonly HashSet<string> compilerLogRepositoryRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         private SolutionGenerator(
             string solutionFilePath,
             string solutionDestinationFolder,
@@ -246,10 +248,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         /// </summary>
         public static Microsoft.CodeAnalysis.SolutionInfo NormalizeCompilerLogAssemblyNames(
             Microsoft.CodeAnalysis.SolutionInfo solutionInfo,
-            IReadOnlyDictionary<string, string> repoPathMappings = null)
+            IReadOnlyDictionary<string, string> repoPathMappings = null,
+            IEnumerable<string> compilerLogRepositoryRoots = null)
         {
             var projectInfos = solutionInfo.Projects
-                .Select(p => NormalizeCompilerLogProject(p, repoPathMappings))
+                .Select(p => NormalizeCompilerLogProject(p, repoPathMappings, compilerLogRepositoryRoots))
                 .ToList();
 
             var projectsByAssembly = projectInfos
@@ -268,7 +271,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private static ProjectInfo NormalizeCompilerLogProject(
             ProjectInfo projectInfo,
-            IReadOnlyDictionary<string, string> repoPathMappings)
+            IReadOnlyDictionary<string, string> repoPathMappings,
+            IEnumerable<string> compilerLogRepositoryRoots)
         {
             var normalized = projectInfo.WithAssemblyName(Path.GetFileNameWithoutExtension(projectInfo.AssemblyName));
             var projectDirectory = Path.GetDirectoryName(projectInfo.FilePath);
@@ -277,7 +281,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return normalized;
             }
 
-            var repositoryRoot = (repoPathMappings?.Keys ?? Enumerable.Empty<string>())
+            var repositoryRoot = (compilerLogRepositoryRoots ?? Enumerable.Empty<string>())
+                .Where(path => Paths.IsOrContains(path, projectInfo.FilePath))
+                .OrderBy(path => path.Length)
+                .FirstOrDefault();
+            repositoryRoot ??= (repoPathMappings?.Keys ?? Enumerable.Empty<string>())
                 .Where(path => Paths.IsOrContains(path, projectInfo.FilePath))
                 .OrderBy(path => path.Length)
                 .FirstOrDefault();
@@ -362,6 +370,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         var pathMappings = compilerCall.IsCSharp
                             ? CSharpCommandLineParser.Default.Parse(reader.ReadRawArguments(compilerCall), compilerCall.ProjectDirectory, sdkDirectory: null).PathMap
                             : VisualBasicCommandLineParser.Default.Parse(reader.ReadRawArguments(compilerCall), compilerCall.ProjectDirectory, sdkDirectory: null).PathMap;
+                        var repositoryRoot = GetCompilerLogRepositoryRoot(pathMappings);
+                        if (repositoryRoot != null)
+                        {
+                            compilerLogRepositoryRoots.Add(repositoryRoot);
+                        }
+
                         ServerPathMappings = AddCompilerLogServerPathMapping(
                             ServerPathMappings,
                             compilerLogFilePath,
@@ -428,11 +442,15 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         {
             var normalizedRepoPathMappings = CopyServerPathMappings(repoPathMappings);
             var compilerLogFullPath = Path.GetFullPath(compilerLogFilePath);
-            var compilerLogDirectory = Path.GetDirectoryName(compilerLogFullPath);
-            if (!normalizedRepoPathMappings.Keys.Any(mapping => Paths.IsOrContains(mapping, compilerLogFullPath)))
+            var configuredRepositoryRoot = normalizedRepoPathMappings.Keys
+                .Where(mapping => Paths.IsOrContains(mapping, compilerLogFullPath))
+                .OrderBy(mapping => mapping.Length)
+                .FirstOrDefault();
+            if (configuredRepositoryRoot == null)
             {
                 return repoPathMappings;
             }
+            configuredRepositoryRoot = Path.GetFullPath(configuredRepositoryRoot);
 
             var repositoryRoot = GetCompilerLogRepositoryRoot(compilerPathMappings);
             if (repositoryRoot == null)
@@ -443,12 +461,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             foreach (var mapping in repoPathMappings ?? Enumerable.Empty<KeyValuePair<string, string>>())
             {
                 var mappingPath = Path.GetFullPath(mapping.Key);
-                if (!Paths.IsOrContains(compilerLogDirectory, mappingPath))
+                if (!Paths.IsOrContains(configuredRepositoryRoot, mappingPath))
                 {
                     continue;
                 }
 
-                var relativePath = Path.GetRelativePath(compilerLogDirectory, mappingPath);
+                var relativePath = Path.GetRelativePath(configuredRepositoryRoot, mappingPath);
                 var originalPath = relativePath == "."
                     ? repositoryRoot
                     : Path.Combine(repositoryRoot, relativePath);
@@ -880,7 +898,10 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         solutionFilePath,
                         BasicAnalyzerKind.None);
                     this.compilerLogReader = reader;
-                    var solutionInfo = NormalizeCompilerLogAssemblyNames(reader.ReadSolutionInfo(), RepoPathMappings);
+                    var solutionInfo = NormalizeCompilerLogAssemblyNames(
+                        reader.ReadSolutionInfo(),
+                        RepoPathMappings,
+                        compilerLogRepositoryRoots);
 
                     var adhocWorkspace = new AdhocWorkspace();
                     adhocWorkspace.AddSolution(solutionInfo);

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -237,14 +237,19 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         /// which keys output folders, the global assembly list, and cross-assembly references off the
         /// bare name -- uses the extension-less form. This rewrites every project's AssemblyName to the
         /// extension-less form so a .complog input produces byte-for-byte the same output as the
-        /// equivalent .binlog input. When multiple compilations produce the same assembly, the one
-        /// with the most source documents is ordered first so downstream first-wins deduplication
-        /// prefers an implementation build over a reference assembly.
+        /// equivalent .binlog input. Compiler logs also retain source file paths but not Roslyn
+        /// document folders, so reconstruct project-relative folders for ordinary files and
+        /// repository-relative folders for linked files, matching BinLogToSln's Link behavior.
+        /// When multiple compilations produce the same assembly, the one with the most source
+        /// documents is ordered first so downstream first-wins deduplication prefers an implementation
+        /// build over a reference assembly.
         /// </summary>
-        public static Microsoft.CodeAnalysis.SolutionInfo NormalizeCompilerLogAssemblyNames(Microsoft.CodeAnalysis.SolutionInfo solutionInfo)
+        public static Microsoft.CodeAnalysis.SolutionInfo NormalizeCompilerLogAssemblyNames(
+            Microsoft.CodeAnalysis.SolutionInfo solutionInfo,
+            IReadOnlyDictionary<string, string> repoPathMappings = null)
         {
             var projectInfos = solutionInfo.Projects
-                .Select(p => p.WithAssemblyName(Path.GetFileNameWithoutExtension(p.AssemblyName)))
+                .Select(p => NormalizeCompilerLogProject(p, repoPathMappings))
                 .ToList();
 
             var projectsByAssembly = projectInfos
@@ -259,6 +264,65 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             return Microsoft.CodeAnalysis.SolutionInfo.Create(
                 solutionInfo.Id, solutionInfo.Version, solutionInfo.FilePath, projectInfos);
+        }
+
+        private static ProjectInfo NormalizeCompilerLogProject(
+            ProjectInfo projectInfo,
+            IReadOnlyDictionary<string, string> repoPathMappings)
+        {
+            var normalized = projectInfo.WithAssemblyName(Path.GetFileNameWithoutExtension(projectInfo.AssemblyName));
+            var projectDirectory = Path.GetDirectoryName(projectInfo.FilePath);
+            if (string.IsNullOrEmpty(projectDirectory))
+            {
+                return normalized;
+            }
+
+            var repositoryRoot = (repoPathMappings?.Keys ?? Enumerable.Empty<string>())
+                .Where(path => Paths.IsOrContains(path, projectInfo.FilePath))
+                .OrderBy(path => path.Length)
+                .FirstOrDefault();
+
+            return normalized.WithDocuments(projectInfo.Documents.Select(document =>
+                AddCompilerLogDocumentFolders(document, projectDirectory, repositoryRoot)));
+        }
+
+        internal static DocumentInfo AddCompilerLogDocumentFolders(
+            DocumentInfo document,
+            string projectDirectory,
+            string repositoryRoot)
+        {
+            if (document.Folders.Count > 0 ||
+                string.IsNullOrEmpty(document.FilePath) ||
+                !Path.IsPathRooted(document.FilePath) ||
+                !Path.IsPathRooted(projectDirectory))
+            {
+                return document;
+            }
+
+            string relativePath;
+            if (Paths.IsOrContains(projectDirectory, document.FilePath))
+            {
+                relativePath = Path.GetRelativePath(projectDirectory, document.FilePath);
+            }
+            else if (!string.IsNullOrEmpty(repositoryRoot) &&
+                     Paths.IsOrContains(repositoryRoot, document.FilePath))
+            {
+                relativePath = Path.GetRelativePath(repositoryRoot, document.FilePath);
+            }
+            else
+            {
+                return document;
+            }
+
+            var directory = Path.GetDirectoryName(relativePath);
+            if (string.IsNullOrEmpty(directory))
+            {
+                return document;
+            }
+
+            return document.WithFolders(directory.Split(
+                new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                StringSplitOptions.RemoveEmptyEntries));
         }
 
         /// <summary>
@@ -816,7 +880,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         solutionFilePath,
                         BasicAnalyzerKind.None);
                     this.compilerLogReader = reader;
-                    var solutionInfo = NormalizeCompilerLogAssemblyNames(reader.ReadSolutionInfo());
+                    var solutionInfo = NormalizeCompilerLogAssemblyNames(reader.ReadSolutionInfo(), RepoPathMappings);
 
                     var adhocWorkspace = new AdhocWorkspace();
                     adhocWorkspace.AddSolution(solutionInfo);

--- a/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -93,6 +93,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             ImmutableDictionary<string, string> properties,
             Federation federation,
             IReadOnlyDictionary<string, string> serverPathMappings,
+            IReadOnlyDictionary<string, string> repoPathMappings,
             IEnumerable<string> pluginBlacklist,
             IReadOnlyDictionary<ValueTuple<string, string>, string> typeForwards,
             bool includeSourceGeneratedDocuments)
@@ -101,6 +102,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.SolutionDestinationFolder = solutionDestinationFolder;
             this.ProjectFilePath = solutionFilePath;
             ServerPathMappings = CopyServerPathMappings(serverPathMappings);
+            RepoPathMappings = CopyServerPathMappings(repoPathMappings);
             this.Federation = federation ?? new Federation();
             this.PluginBlacklist = pluginBlacklist ?? Enumerable.Empty<string>();
             this.Properties = properties;
@@ -115,6 +117,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             ImmutableDictionary<string, string> properties = null,
             Federation federation = null,
             IReadOnlyDictionary<string, string> serverPathMappings = null,
+            IReadOnlyDictionary<string, string> repoPathMappings = null,
             IEnumerable<string> pluginBlacklist = null,
             IReadOnlyDictionary<ValueTuple<string, string>, string> typeForwards = null,
             bool doNotIncludeReferencedProjects = false,
@@ -126,6 +129,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 properties,
                 federation,
                 serverPathMappings,
+                repoPathMappings,
                 pluginBlacklist,
                 typeForwards,
                 includeSourceGeneratedDocuments
@@ -233,13 +237,26 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         /// which keys output folders, the global assembly list, and cross-assembly references off the
         /// bare name -- uses the extension-less form. This rewrites every project's AssemblyName to the
         /// extension-less form so a .complog input produces byte-for-byte the same output as the
-        /// equivalent .binlog input.
+        /// equivalent .binlog input. When multiple compilations produce the same assembly, the one
+        /// with the most source documents is ordered first so downstream first-wins deduplication
+        /// prefers an implementation build over a reference assembly.
         /// </summary>
         public static Microsoft.CodeAnalysis.SolutionInfo NormalizeCompilerLogAssemblyNames(Microsoft.CodeAnalysis.SolutionInfo solutionInfo)
         {
             var projectInfos = solutionInfo.Projects
                 .Select(p => p.WithAssemblyName(Path.GetFileNameWithoutExtension(p.AssemblyName)))
                 .ToList();
+
+            var projectsByAssembly = projectInfos
+                .GroupBy(p => p.AssemblyName, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => new Queue<ProjectInfo>(g.OrderByDescending(p => p.Documents.Count)),
+                    StringComparer.OrdinalIgnoreCase);
+            projectInfos = projectInfos
+                .Select(p => projectsByAssembly[p.AssemblyName].Dequeue())
+                .ToList();
+
             return Microsoft.CodeAnalysis.SolutionInfo.Create(
                 solutionInfo.Id, solutionInfo.Version, solutionInfo.FilePath, projectInfos);
         }
@@ -285,6 +302,10 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                             ServerPathMappings,
                             compilerLogFilePath,
                             pathMappings);
+                        RepoPathMappings = AddCompilerLogRepoPathMappings(
+                            RepoPathMappings,
+                            compilerLogFilePath,
+                            pathMappings);
                     }
                     catch (Exception ex)
                     {
@@ -326,6 +347,55 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return serverPathMappings;
             }
 
+            var repositoryRoot = GetCompilerLogRepositoryRoot(compilerPathMappings);
+            if (repositoryRoot == null)
+            {
+                return serverPathMappings;
+            }
+
+            normalizedServerPathMappings[repositoryRoot] = configuredMapping.Value;
+            return normalizedServerPathMappings;
+        }
+
+        internal static IReadOnlyDictionary<string, string> AddCompilerLogRepoPathMappings(
+            IReadOnlyDictionary<string, string> repoPathMappings,
+            string compilerLogFilePath,
+            IEnumerable<KeyValuePair<string, string>> compilerPathMappings)
+        {
+            var normalizedRepoPathMappings = CopyServerPathMappings(repoPathMappings);
+            var compilerLogFullPath = Path.GetFullPath(compilerLogFilePath);
+            var compilerLogDirectory = Path.GetDirectoryName(compilerLogFullPath);
+            if (!normalizedRepoPathMappings.Keys.Any(mapping => Paths.IsOrContains(mapping, compilerLogFullPath)))
+            {
+                return repoPathMappings;
+            }
+
+            var repositoryRoot = GetCompilerLogRepositoryRoot(compilerPathMappings);
+            if (repositoryRoot == null)
+            {
+                return repoPathMappings;
+            }
+
+            foreach (var mapping in repoPathMappings ?? Enumerable.Empty<KeyValuePair<string, string>>())
+            {
+                var mappingPath = Path.GetFullPath(mapping.Key);
+                if (!Paths.IsOrContains(compilerLogDirectory, mappingPath))
+                {
+                    continue;
+                }
+
+                var relativePath = Path.GetRelativePath(compilerLogDirectory, mappingPath);
+                var originalPath = relativePath == "."
+                    ? repositoryRoot
+                    : Path.Combine(repositoryRoot, relativePath);
+                normalizedRepoPathMappings[Paths.EnsureTrailingSlash(Path.GetFullPath(originalPath))] = mapping.Value;
+            }
+
+            return normalizedRepoPathMappings;
+        }
+
+        private static string GetCompilerLogRepositoryRoot(IEnumerable<KeyValuePair<string, string>> compilerPathMappings)
+        {
             var repositoryRoot = compilerPathMappings
                 .Where(mapping => Path.IsPathRooted(mapping.Key))
                 .FirstOrDefault(mapping =>
@@ -333,13 +403,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         mapping.Value.Replace('\\', '/').TrimEnd('/'),
                         "/_",
                         StringComparison.OrdinalIgnoreCase));
-            if (repositoryRoot.Key == null)
-            {
-                return serverPathMappings;
-            }
-
-            normalizedServerPathMappings[Paths.EnsureTrailingSlash(Path.GetFullPath(repositoryRoot.Key))] = configuredMapping.Value;
-            return normalizedServerPathMappings;
+            return repositoryRoot.Key == null
+                ? null
+                : Paths.EnsureTrailingSlash(Path.GetFullPath(repositoryRoot.Key));
         }
 
         private static Dictionary<string, string> CopyServerPathMappings(

--- a/src/SourceBrowser/src/HtmlGenerator/Program.cs
+++ b/src/SourceBrowser/src/HtmlGenerator/Program.cs
@@ -561,6 +561,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                             properties: properties.ToImmutableDictionary(),
                             federation: federation,
                             serverPathMappings: serverPathMappings,
+                            repoPathMappings: repoPathMappings,
                             pluginBlacklist: pluginBlacklist,
                             doNotIncludeReferencedProjects: doNotIncludeReferencedProjects,
                             includeSourceGeneratedDocuments: includeSourceGeneratedDocuments,
@@ -572,7 +573,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         solutionGenerator.GlobalAssemblyList = assemblyNames;
                         solutionGenerator.RepoName = repoName;
                         solutionGenerator.SolutionName = solutionName;
-                        solutionGenerator.RepoPathMappings = repoPathMappings;
                         solutionGenerator.DistinctRepoCount = distinctRepoCount;
                         solutionGenerator.SolutionCountsByRepo = solutionCountsByRepo;
                         using (Disposable.Timing("Pass1 writing for " + path))


### PR DESCRIPTION
Should fix these issues for complog-based indexes:
- VMR subrepos aren't handled correctly (`dotnet/` prefix is missing, they don't appear in the filter dropdown)
- Paths are flattened (`source.dot.net/System.Private.CoreLib/src/runtime/src/libraries/System.Private.CoreLib/src/System/String.cs.html` becomes just `source.dot.net/String.cs.html` which also breaks a smoke test in the pipeline, see https://dev.azure.com/dnceng/internal/_build/results?buildId=3060087&view=results)